### PR TITLE
Update man pages for default metric changes

### DIFF
--- a/src/dhcpcd.8.in
+++ b/src/dhcpcd.8.in
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 2, 2021
+.Dd August 23, 2021
 .Dt DHCPCD 8
 .Os
 .Sh NAME
@@ -414,9 +414,10 @@ See the Multiple Interfaces section above.
 .It Fl m , Fl Fl metric Ar metric
 Metrics are used to prefer an interface over another one, lowest wins.
 .Nm
-will supply a default metic of 200 +
-.Xr if_nametoindex 3 .
-An extra 100 will be added for wireless interfaces.
+will supply a default metric starting at
+.Xr if_nametoindex 3 ,
+offset by 2000000 for roaming interfaces, 1000000 for IPv4LL, 2000 for wireless
+interfaces, and 1000 otherwise.
 .It Fl n , Fl Fl rebind Op Ar interface
 Notifies
 .Nm

--- a/src/dhcpcd.8.in
+++ b/src/dhcpcd.8.in
@@ -414,10 +414,10 @@ See the Multiple Interfaces section above.
 .It Fl m , Fl Fl metric Ar metric
 Metrics are used to prefer an interface over another one, lowest wins.
 .Nm
-will supply a default metric starting at
-.Xr if_nametoindex 3 ,
-offset by 2000000 for roaming interfaces, 1000000 for IPv4LL, 2000 for wireless
-interfaces, and 1000 otherwise.
+will supply a default metric of 1000 +
+.Xr if_nametoindex 3 .
+This will be offset by 2000 for wireless interfaces, with additional offsets
+of 1000000 for IPv4LL and 2000000 for roaming interfaces.
 .It Fl n , Fl Fl rebind Op Ar interface
 Notifies
 .Nm

--- a/src/dhcpcd.conf.5.in
+++ b/src/dhcpcd.conf.5.in
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd Febrary 2, 2021
+.Dd August 23, 2021
 .Dt DHCPCD.CONF 5
 .Os
 .Sh NAME
@@ -491,9 +491,10 @@ signal.
 .It Ic metric Ar metric
 Metrics are used to prefer an interface over another one, lowest wins.
 .Nm dhcpcd
-will supply a default metric of 200 +
-.Xr if_nametoindex 3 .
-An extra 100 will be added for wireless interfaces.
+will supply a default metric starting at
+.Xr if_nametoindex 3 ,
+offset by 2000000 for roaming interfaces, 1000000 for IPv4LL, 2000 for wireless
+interfaces, and 1000 otherwise.
 .It Ic mudurl Ar url
 Specifies the URL for a Manufacturer Usage Description (MUD).
 The description is used by upstream network devices to instantiate any

--- a/src/dhcpcd.conf.5.in
+++ b/src/dhcpcd.conf.5.in
@@ -491,10 +491,10 @@ signal.
 .It Ic metric Ar metric
 Metrics are used to prefer an interface over another one, lowest wins.
 .Nm dhcpcd
-will supply a default metric starting at
-.Xr if_nametoindex 3 ,
-offset by 2000000 for roaming interfaces, 1000000 for IPv4LL, 2000 for wireless
-interfaces, and 1000 otherwise.
+will supply a default metric of 1000 +
+.Xr if_nametoindex 3 .
+This will be offset by 2000 for wireless interfaces, with additional offsets
+of 1000000 for IPv4LL and 2000000 for roaming interfaces.
 .It Ic mudurl Ar url
 Specifies the URL for a Manufacturer Usage Description (MUD).
 The description is used by upstream network devices to instantiate any


### PR DESCRIPTION
In commit 3547ed19, the default metric offsets were changed. This PR updates the man pages accordingly.