### PR TITLE
Fix getting VLANID on BSD systems with privilege separation

### DIFF
--- a/src/privsep-bsd.c
+++ b/src/privsep-bsd.c
@@ -33,6 +33,14 @@
 #include <netinet/in.h>
 #include <netinet6/in6_var.h>
 #include <netinet6/nd6.h>
+#ifdef __NetBSD__
+#include <netinet/if_ether.h>
+#include <net/if_vlanvar.h> /* Needs netinet/if_ether.h */
+#elif defined(__DragonFly__)
+#include <net/vlan/if_vlan_var.h>
+#else
+#include <net/if_vlan_var.h>
+#endif
 #ifdef __DragonFly__
 #  include <netproto/802_11/ieee80211_ioctl.h>
 #else


### PR DESCRIPTION
Trying to delegate a prefix to multiple VLANs sharing a physical link, dhcpcd complained about conflicting IAIDs.

Configuration:

```
noipv6rs
allowinterfaces bge1
interface bge1
  ipv6rs
  ia_na 1
  ia_pd 2 vlan1/1/64/0 vlan2/2/64/0 vlan3/3/64/0
```

Log messages:

```
vlan2: IAID conflicts with one assigned to vlan1
vlan3: IAID conflicts with one assigned to vlan1
```

It turns out that the SIOCGETVLAN from if_vlanid() eventually ends up being filtered by ps_root_doioctldom() which doesn't know it.  Including the relevant headers fixes the problem.

I have only tested this on FreeBSD.  I expect this fix to work on other BSD systems too.