### PR TITLE
Add epair(4) to the ignored interface types list

### DIFF
--- a/src/if-bsd.c
+++ b/src/if-bsd.c
@@ -104,6 +104,7 @@
  * just won't work without explicit configuration. */
 static const char * const ifnames_ignore[] = {
 	"bridge",
+	"epair",	/* Virtual patch cable */
 	"fwe",		/* Firewire */
 	"fwip",		/* Firewire */
 	"tap",


### PR DESCRIPTION
The FreeBSD epair(4) interface type can be thought of as a virtual patch cable.
The epair interfaces come in pairs, with network traffic being passed between the 2 pairs.
The basic intent is to provide connectivity between two virtual network stack instances.
This interface type does not typically require an IP address, as it is passing traffic
between other virtual networks/interfaces which obtain their own IP address.
Therefore, add this interface type to the list that will be ignored by dhcpcd.