### PR TITLE
Fix handling of hostname argument

### DIFF
--- a/src/if-options.c
+++ b/src/if-options.c
@@ -264,7 +264,7 @@ parse_str(char *sbuf, size_t slen, const char *str, int flags)
 			str++;
 			end = p;
 		}
-	} else {
+	} else if (flags != PARSE_STRING_NULL) {
 		l = (size_t)hwaddr_aton(NULL, str);
 		if ((ssize_t) l != -1 && l > 1) {
 			if (l > slen) {


### PR DESCRIPTION
"hostname" argument (-h) is a simple string and should never be
interpreted as a hex string.  It is also kept as a null terminated
string, so when we parse something that is meant to be null terminated
string do not attempt to parse it as a HW addressa.  The same applies to
"script" (-c) argument.

Signed-off-by: Andrzej Ostruszka <amo@semihalf.com>