### PR TITLE
add support for loongarch64

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -196,6 +196,12 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #  endif
 #elif defined(__ia64__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_IA64
+#elif defined(__loongarch__)
+#  if defined(__LP64__)
+#    define SECCOMP_AUDIT_ARCH AUDIT_ARCH_LOONGARCH64
+#  else
+#    define SECCOMP_AUDIT_ARCH AUDIT_ARCH_LOONGARCH32
+#  endif
 #elif defined(__microblaze__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_MICROBLAZE
 #elif defined(__m68k__)


### PR DESCRIPTION
LoongArch is a new instruction set of Loongson 3A5000 CPU, you can read the [documents](https://github.com/loongson/LoongArch-Documentation) to get more infomation.

This PR add support for the LoongArch architecture, please review, thanks.