### PR TITLE
Update ver 8 dhcp.c to Fix infinite INFORM messages 

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -4058,7 +4058,7 @@ dhcp_handleifa(int cmd, struct ipv4_addr *ia, pid_t pid)
 
 	ifo = ifp->options;
 	if (ifo->options & DHCPCD_INFORM) {
-		if (state->state != DHS_INFORM)
+		if (state->state != DHS_INFORM && state->state != DHS_BOUND)
 			dhcp_inform(ifp);
 		return ia;
 	}


### PR DESCRIPTION
Applying [change from dhcpcd-9](https://github.com/NetworkConfiguration/dhcpcd/commit/63eacc1a92bac298e1069516dab7b305db70a208) to dhcpcd-8, which is the version in current use for RPi bullseye. 

I'm submitting this as a Draft Pull Request pending a build & test on my RPi 3B+. This may take a while due to my lack of experience :)  If you maintainers are more confident than I, please don't wait on me. I've been put in the position of a "`inform` option Evangelist", and I need to get this working! 


```
$ dhcpcd --version
dhcpcd 8.1.2
Copyright (c) 2006-2019 Roy Marples
Compiled in features: INET ARP ARPing IPv4LL INET6 DHCPv6 AUTH
```