### PR TITLE
Always skip hooks ending in ~

### DIFF
--- a/hooks/dhcpcd-run-hooks.in
+++ b/hooks/dhcpcd-run-hooks.in
@@ -338,9 +338,11 @@ for hook in \
 	@HOOKDIR@/* \
 	@SYSCONFDIR@/dhcpcd.exit-hook
 do
+	case "$hook" in
+		*/*~)	continue;;
+	esac
 	for skip in $skip_hooks; do
 		case "$hook" in
-			*/*~)				continue 2;;
 			*/"$skip")			continue 2;;
 			*/[0-9][0-9]"-$skip")		continue 2;;
 			*/[0-9][0-9]"-$skip.sh")	continue 2;;


### PR DESCRIPTION
dhcpcd-run-hooks is intended to skip hooks with filenames ending in `~`, but the test only works if `$skip_hooks` is defined and not empty.  Refactor the test such that files ending in `~` are always skipped, as appears to be the intent of this code.

Fixes #112 