### PR TITLE
On FreeBSD, don't send SIOCSPFXFLUSH_IN6

### DIFF
--- a/src/if-bsd.c
+++ b/src/if-bsd.c
@@ -1906,12 +1906,6 @@ if_setup_inet6(const struct interface *ifp)
 		    &ifr, sizeof(ifr)) == -1 &&
 		    errno != ENOTSUP && errno != ENOTTY)
 			logwarn("SIOCSRTRFLUSH_IN6 %d", errno);
-#ifdef SIOCSPFXFLUSH_IN6
-		if (if_ioctl6(ifp->ctx, SIOCSPFXFLUSH_IN6,
-		    &ifr, sizeof(ifr)) == -1 &&
-		    errno != ENOTSUP && errno != ENOTTY)
-			logwarn("SIOCSPFXFLUSH_IN6");
-#endif
 	}
 #endif
 }


### PR DESCRIPTION
Unless this portion of code is removed, routes which belong to bridge0 interface (unrelated to the interface being configured) are removed. For example

```
# ifconfig bridge0 inet6 -ifdisabled auto_linklocal fd10:6c79:8ae5:8b92::1
# netstat -rn | grep fd10
fd10:6c79:8ae5:8b92::/64          link#6                        U       bridge0
fd10:6c79:8ae5:8b92::1            link#6                        UHS         lo0
# dhcpcd -B re0 # interupt after a while
# netstat -rn | grep fd10
fd10:6c79:8ae5:8b92::1            link#6                        UHS         lo0
```

I don't know what exactly is wrong, but this at least narrows it down. I don't expect this PR will be accepted in the current state, but I thought PR is the best way to show my findings.