### PR TITLE
hooks/20-resolv.conf: early return instead of remove_resolv_conf

### DIFF
--- a/hooks/20-resolv.conf
+++ b/hooks/20-resolv.conf
@@ -136,12 +136,11 @@ add_resolv_conf()
 		fi
 	fi
 
-	# If we don't have any configuration, remove it
+	# If we don't have any configuration, early return
 	if [ -z "$new_domain_name_servers" ] &&
 	   [ -z "$new_domain_name" ] &&
 	   [ -z "$new_domain_search" ]; then
-		remove_resolv_conf
-		return $?
+		return 0
 	fi
 
 	if [ -n "$new_domain_name" ]; then


### PR DESCRIPTION
In practice, this script is executed again and again. Except for the a few early ones, the remaining executions all met the condition that there's no configuration. Yet, the DNS server is still there. So instead of removing resolv.conf, we'd better just early return here.

Fixes issue#146.

Signed-off-by: Chen Qi <Qi.Chen@windriver.com>