### PR TITLE
20-resolv.conf: in case of IPv6 RA, allow for lacking DNS info

### DIFF
--- a/hooks/20-resolv.conf
+++ b/hooks/20-resolv.conf
@@ -140,8 +140,12 @@ add_resolv_conf()
 	if [ -z "$new_domain_name_servers" ] &&
 	   [ -z "$new_domain_name" ] &&
 	   [ -z "$new_domain_search" ]; then
-		remove_resolv_conf
-		return $?
+		if [ "$reason" = "ROUTERADVERT" ]; then
+			return 0
+		else
+			remove_resolv_conf
+			return $?
+		fi
 	fi
 
 	if [ -n "$new_domain_name" ]; then


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc8106:
"""
These issues are not pressing in dual-stack networks as long as a DNS server is available on the IPv4 side, but they become more critical with the deployment of IPv6-only networks. As a result, this document defines a mechanism based on DNS RA options to allow IPv6 hosts to perform automatic DNS configuration.
"""

According to the above statements, automatic DNS configuration is optional in IPv6 RA, as long as IPv4 has got DNS information. So we should allow for lacking DNS info in case of IPv6 RA.

Signed-off-by: Chen Qi <Qi.Chen@windriver.com>