### PR TITLE
Fix incorrect CTASSERT in ND_OPT_DNSSL

### DIFF
--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -92,7 +92,7 @@ struct nd_opt_dnssl {		/* DNSSL option RFC 6106 */
 	uint32_t	nd_opt_dnssl_lifetime;
 	/* followed by list of DNS servers */
 };
-__CTASSERT(sizeof(struct nd_opt_rdnss) == 8);
+__CTASSERT(sizeof(struct nd_opt_dnssl) == 8);
 #endif
 
 /* Impossible options, so we can easily add extras */


### PR DESCRIPTION
The __CTASSERT within ND_OPT_DNSSL is incorrectly referencing nd_opt_rdnss instead of nd_opt_dnss.

The error was undetected until now because both are equal in size...