### PR TITLE
privsep-linux: fix SECCOMP_AUDIT_ARCH missing ppc64le

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -232,7 +232,11 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #elif defined(__or1k__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_OPENRISC
 #elif defined(__powerpc64__)
-#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64
+#  if (BYTE_ORDER == LITTLE_ENDIAN)
+#    define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64LE
+#  else
+#    define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64
+#  endif
 #elif defined(__powerpc__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC
 #elif defined(__riscv)


### PR DESCRIPTION
Behavior: When dhcpcd runs on the ppc64le platform, it would be killed by SIGSYS.

After enabling seccomp debug in privsep-linux, the SIGSYS signal handler shows us the arch is ppc64 not ppc64le, so add ppc64le support in privsep-linux.c

Thanks.