### PR TITLE
risc-v fix vendor error

### DIFF
--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -202,6 +202,8 @@ static const char *mproc =
 	"cpu"
 #elif defined(__vax__)
 	"cpu"
+#elif defined(__riscv)
+	"uarch"
 #else
 	NULL
 #endif

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -182,18 +182,20 @@ static const char *mproc =
 	"cpu model"
 #elif defined(__frv__)
 	"System"
+#elif defined(__hppa__)
+	"model"
 #elif defined(__i386__) || defined(__x86_64__)
 	"vendor_id"
 #elif defined(__ia64__)
 	"vendor"
-#elif defined(__hppa__)
-	"model"
 #elif defined(__m68k__)
 	"MMU"
 #elif defined(__mips__)
 	"system type"
 #elif defined(__powerpc__) || defined(__powerpc64__)
 	"machine"
+#elif defined(__riscv)
+	"uarch"
 #elif defined(__s390__) || defined(__s390x__)
 	"Manufacturer"
 #elif defined(__sh__)
@@ -202,8 +204,6 @@ static const char *mproc =
 	"cpu"
 #elif defined(__vax__)
 	"cpu"
-#elif defined(__riscv)
-	"uarch"
 #else
 	NULL
 #endif


### PR DESCRIPTION
Hi!

This is nothing significant, but rather a slight annoyance.

When using dhcpcd on risc-v, You get the error "dhcp_vendor: Invalid argument", investigating further I saw that the mproc string used by if_machinearch is defined as NULL under risc-v, which makes it fail, Im not entirly sure what exact info needs to be returned since some arches have the model, some have the vendor and some have the mmu, etc, so I decided to use uarch since it contains both a model and a vendor name, in case that is not ideal here is other variables that could be used

isa : rv64imafdc
mmu : sv39
uarch : sifive,u74-mc

(reference star64 sbc running Linux-5.15.107)