### PR TITLE
Additional DHCP options

### DIFF
--- a/src/dhcpcd-definitions.conf
+++ b/src/dhcpcd-definitions.conf
@@ -175,6 +175,9 @@ define 101	string			tzdb_timezone
 # DHCP IPv6-Only Preferred, RFC8925
 define 108	uint32			ipv6_only_preferred
 
+# DHCP Captive Portal, RFC8910
+define 114	string			captive_portal_uri
+
 # DHCP Auto-Configuration, RFC2563
 define 116	byte			auto_configure
 
@@ -266,7 +269,11 @@ embed		ipaddress		primary
 embed		ipaddress		secondary
 embed		array domain		domains
 
-# Options 147, 148 and 149 are unused, RFC3942
+# Option 149 is unused, RFC3942
+
+# DHCP DOTS, DDoS Open Threat Signaling (DOTS) Agent Discovery RFC8973
+define 147	domain			dots_ri
+define 148	array ipaddress		dots_address
 
 # DHCP TFTP Server Address, RFC5859
 define 150	array ipaddress		tftp_servers
@@ -285,7 +292,7 @@ define 150	array ipaddress		tftp_servers
 #define 156	byte			blklqry_state
 #define 157	bitflags=0000000R	blklqry_source
 
-# DHCP MUD URL, draft-ietf-opsawg-mud
+# DHCP MUD URL, RFC8520
 define 161	string			mudurl
 
 # Apart from 161...
@@ -638,8 +645,15 @@ encap	92	option
 # DHCPv6 Address Selection Policy
 # Currently not supported
 
-# DHCPv6 MUD URL, draft-ietf-opsawg-mud
+# DHCPv6 MUD URL, RFC8520
 define6 112	string			mudurl
+
+# DHCP Captive Portal, RFC8910
+define6 103	string			captive_portal_uri
+
+# DHCP DDoS Open Threat Signaling (DOTS) Agent Discovery, RFC8973
+define6 141	domain			dots_ri
+define6 142	array ip6address	dots_address
 
 # Options 86-65535 are unasssinged
 


### PR DESCRIPTION
DDoS Open Threat Signaling (DOTS) Agent Discovery, RFC8973
DHCP option 147,147; DHCPv6 option 141,142

Captive Portal, RFC8910
DHCP option 114; DHCVv6 option 104

update to attribution for MUD URL - RFC8520