### PR TITLE
Fixing Segfault in privsep-root 10.0.1

### DIFF
--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -962,15 +962,19 @@ ps_root_stop(struct dhcpcd_ctx *ctx)
 	 * log dhcpcd exits because the latter requires the former.
 	 * So we just log the intent to exit.
 	 * Even sending this will be a race to exit. */
-	if (psp) {
-		logdebugx("%s%s%s will exit from PID %d",
-		    psp->psp_ifname,
-		    psp->psp_ifname[0] != '\0' ? ": " : "",
-		    psp->psp_name, psp->psp_pid);
+
+	if (getuid() == 0 ) {
+		if (psp) {
+			logdebugx("%s%s%s will exit from PID %d",
+				psp->psp_ifname,
+				psp->psp_ifname[0] != '\0' ? ": " : "",
+				psp->psp_name, psp->psp_pid);
+		}
+	}
 
 		if (ps_stopprocess(psp) == -1)
 			return -1;
-	} /* else the root process has already exited :( */
+	 /* else the root process has already exited :( */
 
 	return ps_stopwait(ctx);
 }
@@ -1019,6 +1023,9 @@ ps_root_ioctl(struct dhcpcd_ctx *ctx, ioctl_request_t req, void *data,
 ssize_t
 ps_root_unlink(struct dhcpcd_ctx *ctx, const char *file)
 {
+	if (getuid() != 0) {
+		return -1;
+	}
 
 	if (ps_sendcmd(ctx, PS_ROOT_FD(ctx), PS_UNLINK, 0,
 	    file, strlen(file) + 1) == -1)


### PR DESCRIPTION
OS: Arch Linux
Version: dhcpcd 10.0.1

Currently, with dhcpcd 10.0.1 when executing the binary as a non-root user, a segfault occurs when dereferencing values from a struct that is not populated.
![error](https://github.com/NetworkConfiguration/dhcpcd/assets/1250113/e9ffb43a-8b09-436e-8955-adfe74e4f8c1)

This PR addresses this issue by checking whether or not the the uid is 0.
![fix](https://github.com/NetworkConfiguration/dhcpcd/assets/1250113/6b11cd2c-c5ca-4d9e-b169-349e0c9911bb)




