### PR TITLE
Add automated CI builds for Ubuntu, OpenBSD, FreeBSD and NetBSD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,86 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CC: clang
+
+jobs:
+  ubuntu:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Configure
+      run: ./configure --prefix=/usr
+
+    - name: Build
+      run: make
+
+  openbsd:
+    runs-on: macos-12
+    steps:
+    - name: Bootstrap OpenBSD-latest
+      uses: mario-campos/emulate@v1
+      with:
+        operating-system: openbsd-latest
+
+    - name: Install Dependencies
+      run: pkg_add git
+
+    - name: Build
+      run: |
+        git clone --depth=1 "${{ github.server_url }}/${{ github.repository }}" build
+        cd build
+        [ "${{ github.event.pull_request.number }}" = "" ] || (echo "fetching PR ${{ github.event.pull_request.number }}"; git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }} && git checkout "pr-${{ github.event.pull_request.number }}")
+        echo "configure"
+        ./configure --prefix=/usr
+        echo "building"
+        make
+
+  freebsd:
+    runs-on: macos-12
+    steps:
+    - name: Bootstrap FreeBSD-latest
+      uses: mario-campos/emulate@v1
+      with:
+        operating-system: freebsd-latest
+
+    - name: Install Dependencies
+      run: pkg install -y git
+
+    - name: Build
+      run: |
+        git clone --depth=1 "${{ github.server_url }}/${{ github.repository }}" build
+        cd build
+        [ "${{ github.event.pull_request.number }}" = "" ] || (echo "fetching PR ${{ github.event.pull_request.number }}"; git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }} && git checkout "pr-${{ github.event.pull_request.number }}")
+        echo "configure"
+        ./configure --prefix=/usr
+        echo "building"
+        make
+
+  netbsd:
+    runs-on: macos-12
+    steps:
+    - name: Bootstrap NetBSD-latest
+      uses: mario-campos/emulate@v1
+      with:
+        operating-system: netbsd-latest
+
+    - name: Build
+      run: |
+        git clone --depth=1 "${{ github.server_url }}/${{ github.repository }}" build
+        cd build
+        [ "${{ github.event.pull_request.number }}" = "" ] || (echo "fetching PR ${{ github.event.pull_request.number }}"; git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }} && git checkout "pr-${{ github.event.pull_request.number }}")
+        echo "configure"
+        ./configure --prefix=/usr
+        echo "building"
+        make


### PR DESCRIPTION
I have added some build automation to my local branch to help me catch eventual bugs in my commits and I thought this might be something worth adding here.

With the proposed configuration, automated builds are triggered for each commit to the master branch and for each pull request against the master branch. I guess this would be quite helpful to find out if a PR breaks any of the supported systems (or at least those we can run in a CI) without testing them all by hand.

The BSDs are not officially supported by github, but I have successfully used https://github.com/mario-campos/emulate for another portable daemon I am working on. It works by creating and running BSD VMs in macos. The builds take a little longer than native ones but otherwise they work just fine.