### PR TITLE
Do not crash on dhcpcd test run

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3314,7 +3314,8 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 			state->reason = "TEST";
 			script_runreason(ifp, state->reason);
 			eloop_exit(ifp->ctx->eloop, EXIT_SUCCESS);
-			state->bpf->bpf_flags |= BPF_EOF;
+			if (state->bpf)
+				state->bpf->bpf_flags |= BPF_EOF;
 			return;
 		}
 		eloop_timeout_delete(ifp->ctx->eloop, send_discover, ifp);


### PR DESCRIPTION
Check if state->bpf is allocated before attempting to write there.