### PR TITLE
dhcpcd: Fix off-by-one overflow when read() writes full BUFSIZ

### DIFF
--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -1822,7 +1822,7 @@ dhcpcd_stderr_cb(void *arg, unsigned short events)
 	if (!(events & ELE_READ))
 		return;
 
-	len = read(ctx->stderr_fd, log, sizeof(log));
+	len = read(ctx->stderr_fd, log, sizeof(log) - 1);
 	if (len == -1) {
 		if (errno != ECONNRESET)
 			logerr(__func__);


### PR DESCRIPTION
Read can return up to `BUFSIZ` bytes. If that happens we zero `log[BUFSIZ]` which is outside the buffer. Found with a long error message and `-fsanitize=address`.