### PR TITLE
privsep: fix strlcpy overflow in psp_ifname

### DIFF
--- a/src/privsep.c
+++ b/src/privsep.c
@@ -1200,7 +1200,7 @@ ps_newprocess(struct dhcpcd_ctx *ctx, struct ps_id *psid)
 #endif
 
 	if (!(ctx->options & DHCPCD_MANAGER))
-		strlcpy(psp->psp_ifname, ctx->ifv[0], sizeof(psp->psp_name));
+		strlcpy(psp->psp_ifname, ctx->ifv[0], sizeof(psp->psp_ifname));
 	TAILQ_INSERT_TAIL(&ctx->ps_processes, psp, next);
 	return psp;
 }


### PR DESCRIPTION
When running our Ubuntu tests with libc6 and strlcpy overflow checks enabled we found that the wrong size is passed to strlcpy resulting in a crash because of an overflow.

For context, here is the test run log: https://autopkgtest.ubuntu.com/results/autopkgtest-mantic/mantic/amd64/d/dhcpcd/20230814_101551_01fd7@/log.gz

And the stack trace from my manual run:
```
Program terminated with signal SIGABRT, Aborted.
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
Download failed: Invalid argument.  Continuing without source file ./nptl/./nptl/pthread_kill.c.
44      ./nptl/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fcee7e42866 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fcee7e268b7 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007fcee7e27750 in __libc_message (fmt=fmt@entry=0x7fcee7fc38d3 "*** %s ***: terminated\n")
    at ../sysdeps/posix/libc_fatal.c:150
#6  0x00007fcee7f37dbb in __GI___fortify_fail (msg=msg@entry=0x7fcee7fc38ba "buffer overflow detected")
    at ./debug/fortify_fail.c:24
#7  0x00007fcee7f37776 in __GI___chk_fail () at ./debug/chk_fail.c:28
#8  0x00007fcee7f391c9 in __strlcpy_chk (s1=s1@entry=0x55fa7a635f54 "", s2=<optimized out>, n=n@entry=76,
    s1len=s1len@entry=16) at ./debug/strlcpy_chk.c:28
#9  0x000055fa7886fe95 in strlcpy (__n=76, __src=<optimized out>, __dest=0x55fa7a635f54 "")
    at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:156
#10 ps_newprocess (ctx=ctx@entry=0x7fff6a08e650, psid=psid@entry=0x7fff6a08e5b0)
    at /build/dhcpcd-KAoqzG/dhcpcd-10.0.2/src/privsep.c:1203
--Type <RET> for more, q to quit, c to continue without paging--
#11 0x000055fa78877272 in ps_root_start (ctx=ctx@entry=0x7fff6a08e650) at /build/dhcpcd-KAoqzG/dhcpcd-10.0.2/src/privsep-root.c:911
#12 0x000055fa788778c0 in ps_start (ctx=0x7fff6a08e650) at /build/dhcpcd-KAoqzG/dhcpcd-10.0.2/src/privsep.c:566
#13 0x000055fa78844b7b in main (argc=8, argv=0x7fff6a08ec18, envp=<optimized out>) at /build/dhcpcd-KAoqzG/dhcpcd-10.0.2/src/dhcpcd.c:2454
``