### PR TITLE
compat: use OpenSSL RAND_priv_bytes() for entropy

### DIFF
--- a/compat/arc4random.c
+++ b/compat/arc4random.c
@@ -40,6 +40,10 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
+#if defined(HAVE_OPENSSL)
+#include <openssl/rand.h>
+#endif
+
 #define KEYSTREAM_ONLY
 #include "chacha_private.h"
 
@@ -92,6 +96,11 @@ _dhcpcd_getentropy(void *buf, size_t length)
 {
 	struct timeval	 tv;
 	uint8_t		*rand = (uint8_t *)buf;
+
+#if defined (HAVE_OPENSSL)
+	if (RAND_priv_bytes(buf, (int)length) == 1)
+		return (0);
+#endif
 
 	if (length < sizeof(tv)) {
 		gettimeofday(&tv, NULL);

--- a/tests/eloop-bench/Makefile
+++ b/tests/eloop-bench/Makefile
@@ -39,7 +39,7 @@ distclean: clean
 depend:
 
 ${PROG}: ${DEPEND} ${OBJS}
-	${CC} ${LDFLAGS} -o $@ ${OBJS}
+	${CC} ${LDFLAGS} -o $@ ${OBJS} ${LDADD}
 
 test: ${PROG}
 	./${PROG}


### PR DESCRIPTION
With the recent OpenSSL addition we can now also use it in a few other places for convenience.

One useful thing it implements is portable high quality entropy generation. We can use it as a replacement for `/dev/urandom` to seed `arc4random()` where it is available.