### PR TITLE
Send correct amount of used buffer for prefix exclude option

### DIFF
--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -1022,9 +1022,11 @@ dhcp6_makemessage(struct interface *ifp)
 						n--;
 					while (n-- > 0)
 						*ep++ = *pp--;
-					if (u8)
+					n = ep - exb;
+					if (u8) {
 						*ep = (uint8_t)(*pp << u8);
-					n++;
+						n++;
+					}
 					COPYIN(D6_OPTION_PD_EXCLUDE, exb,
 					    (uint16_t)n);
 					ia_na_len = (uint16_t)


### PR DESCRIPTION
Fixes issue #246 

The payload of the prefix exclude option was correctly created but the amount of bytes to send in the DHCPv6 request was always set to 0 which resulted in an invalid prefix exclude option

This patch fixes this behavior by calculating the correct amount of bytes to send.