### PR TITLE
compat/arc4random.c: use memset instead of explicit_bzero

### DIFF
--- a/compat/arc4random.c
+++ b/compat/arc4random.c
@@ -195,7 +195,7 @@ _rs_stir(void)
 		_rs_init(rnd, sizeof(rnd));
 	else
 		_rs_rekey(rnd, sizeof(rnd));
-	explicit_bzero(rnd, sizeof(rnd));	/* discard source seed */
+	memset(rnd, 0, sizeof(rnd));	/* discard source seed */
 
 	/* invalidate rs_buf */
 	rs->rs_have = 0;


### PR DESCRIPTION
Use `memset` instead of `explicit_bzero` to avoid the following build failure with uclibc-ng since version 10.0.3 and
https://github.com/NetworkConfiguration/dhcpcd/commit/837d09e34c487edaa92aa2ae71a630d84c927f8e:

```
/home/fabrice/buildroot/output/host/lib/gcc/arm-buildroot-linux-uclibcgnueabi/12.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: ../compat/arc4random.o: in function `_rs_stir_if_needed':
arc4random.c:(.text+0x8cc): undefined reference to `explicit_bzero'
```