### PR TITLE
privsep: allow __NR_mmap2 call

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -364,6 +364,9 @@ static struct sock_filter ps_seccomp_filter[] = {
 #ifdef __NR_mmap
 	SECCOMP_ALLOW(__NR_mmap),
 #endif
+#ifdef __NR_mmap2
+	SECCOMP_ALLOW(__NR_mmap2),
+#endif
 #ifdef __NR_munmap
 	SECCOMP_ALLOW(__NR_munmap),
 #endif


### PR DESCRIPTION
The issue occured while compiled by musl:

    mmap2(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = ?
    +++ killed by SIGSYS +++

This patchs allows seccomp to make __NR_mmap2 syscall.