### PR TITLE
privsep: allow __NR_clock_gettime32 syscall

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -301,6 +301,9 @@ static struct sock_filter ps_seccomp_filter[] = {
 #if defined(__x86_64__) && defined(__ILP32__) && defined(__X32_SYSCALL_BIT)
 	SECCOMP_ALLOW(__NR_clock_gettime & ~__X32_SYSCALL_BIT),
 #endif
+#ifdef __NR_clock_gettime32
+	SECCOMP_ALLOW(__NR_clock_gettime32),
+#endif
 #ifdef __NR_clock_gettime64
 	SECCOMP_ALLOW(__NR_clock_gettime64),
 #endif


### PR DESCRIPTION
musl libc doesn't have __NR_clock_gettime definition, but has __NR_clock_gettime32. clock_gettime implementation fallbacks to 32-bit version if 64-bit is not supported by the kernel.