### PR TITLE
Add definition for option 245

### DIFF
--- a/src/dhcpcd-definitions.conf
+++ b/src/dhcpcd-definitions.conf
@@ -335,6 +335,10 @@ encap 255	flag			global
 
 # Options 224-254 are reserved for Private Use
 
+# Option 245 is an IANA assigned private number used by Azure DHCP servers
+# to provide the IPv4 address of the Azure WireServer endpoint
+define 245	ipaddress		azureendpoint
+
 # Option 249 is an IANA assigned private number used by Windows DHCP servers
 # to provide the exact same information as option 121, classless static routes
 define 249	rfc3442			ms_classless_static_routes


### PR DESCRIPTION
Add definition for the DHCP private option used to advertise the location of the Azure WireServer.
See https://cloudinit.readthedocs.io/en/19.4/topics/datasources/azure.html.

I didn't add the definition to the small configuration it really isn't useful there.
