### PR TITLE
Option 1: Workaround for broken stdin logic

### DIFF
--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -29,7 +29,6 @@
 static const char dhcpcd_copyright[] = "Copyright (c) 2006-2023 Roy Marples";
 
 #include <sys/file.h>
-#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -2242,9 +2241,7 @@ printpidfile:
 #endif
 
 #ifndef SMALL
-	if (ctx.options & DHCPCD_DUMPLEASE &&
-	    ioctl(fileno(stdin), FIONREAD, &i, sizeof(i)) == 0 &&
-	    i > 0)
+	if (ctx.options & DHCPCD_DUMPLEASE && i > 0 && ctx.ifc == 0)
 	{
 		ctx.options |= DHCPCD_FORKED; /* pretend child process */
 #ifdef PRIVSEP


### PR DESCRIPTION
This is my original proposal to fix https://github.com/NetworkConfiguration/dhcpcd/issues/285. It just checks if there was an interface passed and then forces stdin parsing if no interface was passed.

After I implemented it, I read the docs and realized that when no interface was passed, and no stdin is piped that in theory this means that all interfaces should be dumped:

>     -U, --dumplease [interface]
>              Dumps the current lease for the interface to stdout.  If no interface is given then all
>             interfaces are dumped.

Since this approach breaks the intended user interface, I originally assumed you didn't want it. However, after I implemented the second option I realized that this documented behavior that option 2 designs around is [also broken](https://github.com/NetworkConfiguration/dhcpcd/issues/287).

Continued discusion of the options for #285 in the [second PR](https://github.com/NetworkConfiguration/dhcpcd/pull/289).