### PR TITLE
Option 2: Fix stdin parsing

### DIFF
--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -29,7 +29,6 @@
 static const char dhcpcd_copyright[] = "Copyright (c) 2006-2023 Roy Marples";
 
 #include <sys/file.h>
-#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -2243,8 +2242,10 @@ printpidfile:
 
 #ifndef SMALL
 	if (ctx.options & DHCPCD_DUMPLEASE &&
-	    ioctl(fileno(stdin), FIONREAD, &i, sizeof(i)) == 0 &&
-	    i > 0)
+	    i > 0 &&
+	    ctx.ifc == 1 &&
+	    strlen(ctx.ifv[0]) == 1 &&
+	    ctx.ifv[0][0] == '-')
 	{
 		ctx.options |= DHCPCD_FORKED; /* pretend child process */
 #ifdef PRIVSEP


### PR DESCRIPTION
This is my second fix https://github.com/NetworkConfiguration/dhcpcd/issues/285. It checks if there was a single "interface" argument passed and if that argument value is `-`. If such an argument exists, then dhcpcd forcibly waits on stdin. This also removes the unreliable "check if the stdin buffer is full" semantics, which I don't think should break other use cases. Running `dhcpcd -U <interface>` will work just like it did before, by contacting the network manager[1]. I assume you prefer this fix over the [first one I wrote](https://github.com/NetworkConfiguration/dhcpcd/pull/288), because that one breaks the "no interface means dump all interfaces" expectation, but I still offered both fixes for you to decide because that documented expectation [also appears broken](https://github.com/NetworkConfiguration/dhcpcd/issues/287).

[1] this requirement also [seems like a bug](https://github.com/NetworkConfiguration/dhcpcd/issues/286) when the lease file has already been acquired with a `--oneshot` call, but as long as we have _some stable way_ across releases to parse a lease without the daemon running I guess I don't care strongly if that one of these gets fixed