### PR TITLE
Example alternate option 245 implementation

### DIFF
--- a/src/dhcpcd-definitions.conf
+++ b/src/dhcpcd-definitions.conf
@@ -333,16 +333,49 @@ encap 255	flag			global
 
 # Options 222 and 223 are unused, RFC3942
 
-# Options 224-254 are reserved for Private Use
+# Options 224-254 are reserved for Private Use, RFC3942
+
+define 224	binhex			site_specific_224
+define 225	binhex			site_specific_225
+define 226	binhex			site_specific_226
+define 227	binhex			site_specific_227
+define 228	binhex			site_specific_228
+define 229	binhex			site_specific_229
+define 230	binhex			site_specific_230
+define 231	binhex			site_specific_231
+define 232	binhex			site_specific_232
+define 233	binhex			site_specific_233
+define 234	binhex			site_specific_234
+define 235	binhex			site_specific_235
+define 236	binhex			site_specific_236
+define 237	binhex			site_specific_237
+define 238	binhex			site_specific_238
+define 239	binhex			site_specific_239
+define 240	binhex			site_specific_240
+define 241	binhex			site_specific_241
+define 242	binhex			site_specific_242
+define 243	binhex			site_specific_243
+define 244	binhex			site_specific_244
+define 245	binhex			site_specific_245
+define 246	binhex			site_specific_246
+define 247	binhex			site_specific_247
+define 248	binhex			site_specific_248
 
 # Option 249 is an IANA assigned private number used by Windows DHCP servers
 # to provide the exact same information as option 121, classless static routes
+# Not binhex for historical reasons.
 define 249	rfc3442			ms_classless_static_routes
+
+define 250	binhex			site_specific_250
+define 251	binhex			site_specific_251
 
 # An expired RFC for Web Proxy Auto Discovery Protocol does define
 # Option 252 which is commonly used by major browsers.
 # Apparently the code was assigned by agreement of the DHC working group chair.
 define 252	uri			wpad_url
+
+define 253	binhex			site_specific_253
+define 254	binhex			site_specific_254
 
 # Option 255 End
 


### PR DESCRIPTION
Here is an example change that can be used if my continuing the example of option 249 is undesirable.

Added binhex entries for all the site-specific options to src/dhcpcd-definitions.conf so that site specific hooks can make use of them.

The entries were not added to the small definitions file because that seems neither useful nor small.
