### PR TITLE
add RFC4191 support

### DIFF
--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2318,7 +2318,9 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 {
 	struct rt *rt;
 	struct ra *rap;
+	const struct routeinfo *ri;
 	const struct ipv6_addr *addr;
+	struct in6_addr netmask;
 
 	if (ctx->ra_routers == NULL)
 		return 0;
@@ -2326,6 +2328,27 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 	TAILQ_FOREACH(rap, ctx->ra_routers, next) {
 		if (rap->expired)
 			continue;
+
+		/* add rfc4191 route information routes */
+		TAILQ_FOREACH (ri, &rap->routeinfos, next) {
+			if(ri->lifetime == 0)
+				continue;
+			if ((rt = inet6_makeroute(rap->iface, rap)) == NULL)
+				continue;
+
+			in6_addr_fromprefix(&netmask, ri->prefixlength);
+
+			sa_in6_init(&rt->rt_dest, &ri->prefix);
+			sa_in6_init(&rt->rt_netmask, &netmask);
+			sa_in6_init(&rt->rt_gateway, &rap->from);
+#ifdef HAVE_ROUTE_PREF
+			rt->rt_pref = ipv6nd_rtpref(ri->flags);
+#endif
+
+			rt_proto_add(routes, rt);
+		}
+
+		/* add subnet routes */
 		TAILQ_FOREACH(addr, &rap->addrs, next) {
 			if (addr->prefix_vltime == 0)
 				continue;
@@ -2333,11 +2356,13 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 			if (rt) {
 				rt->rt_dflags |= RTDF_RA;
 #ifdef HAVE_ROUTE_PREF
-				rt->rt_pref = ipv6nd_rtpref(rap);
+				rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 				rt_proto_add(routes, rt);
 			}
 		}
+
+		/* add default route */
 		if (rap->lifetime == 0)
 			continue;
 		if (ipv6_anyglobal(rap->iface) == NULL)
@@ -2347,7 +2372,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 			continue;
 		rt->rt_dflags |= RTDF_RA;
 #ifdef HAVE_ROUTE_PREF
-		rt->rt_pref = ipv6nd_rtpref(rap);
+		rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 		rt_proto_add(routes, rt);
 	}

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2318,7 +2318,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 {
 	struct rt *rt;
 	struct ra *rap;
-	const struct routeinfo *ri;
+	const struct routeinfo *rinfo;
 	const struct ipv6_addr *addr;
 	struct in6_addr netmask;
 
@@ -2330,19 +2330,19 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 			continue;
 
 		/* add rfc4191 route information routes */
-		TAILQ_FOREACH (ri, &rap->routeinfos, next) {
-			if(ri->lifetime == 0)
+		TAILQ_FOREACH (rinfo, &rap->rinfos, next) {
+			if(rinfo->lifetime == 0)
 				continue;
 			if ((rt = inet6_makeroute(rap->iface, rap)) == NULL)
 				continue;
 
-			in6_addr_fromprefix(&netmask, ri->prefixlength);
+			in6_addr_fromprefix(&netmask, rinfo->prefix_len);
 
-			sa_in6_init(&rt->rt_dest, &ri->prefix);
+			sa_in6_init(&rt->rt_dest, &rinfo->prefix);
 			sa_in6_init(&rt->rt_netmask, &netmask);
 			sa_in6_init(&rt->rt_gateway, &rap->from);
 #ifdef HAVE_ROUTE_PREF
-			rt->rt_pref = ipv6nd_rtpref(ri->flags);
+			rt->rt_pref = ipv6nd_rtpref(rinfo->flags);
 #endif
 
 			rt_proto_add(routes, rt);

--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -71,6 +71,20 @@
 #define	ND_OPT_PI_FLAG_ROUTER	0x20	/* Router flag in PI */
 #endif
 
+#ifndef ND_OPT_RI
+#define ND_OPT_RI	24
+struct nd_opt_ri {		/* Route Information option RFC4191 */
+	uint8_t	 nd_opt_ri_type;
+	uint8_t	 nd_opt_ri_len;
+	uint8_t	 nd_opt_ri_prefixlen;
+	uint8_t	 nd_opt_ri_flags_reserved;
+	uint32_t nd_opt_ri_lifetime;
+	struct in6_addr nd_opt_ri_prefix;
+};
+__CTASSERT(sizeof(struct nd_opt_ri) == 24);
+#define OPT_RI_FLAG_PREFERENCE(flags) ((flags & 0x18) >> 3)
+#endif
+
 #ifndef ND_OPT_RDNSS
 #define ND_OPT_RDNSS			25
 struct nd_opt_rdnss {           /* RDNSS option RFC 6106 */
@@ -612,10 +626,10 @@ ipv6nd_startexpire(struct interface *ifp)
 }
 
 int
-ipv6nd_rtpref(struct ra *rap)
+ipv6nd_rtpref(uint8_t flags)
 {
 
-	switch (rap->flags & ND_RA_FLAG_RTPREF_MASK) {
+	switch (flags & ND_RA_FLAG_RTPREF_MASK) {
 	case ND_RA_FLAG_RTPREF_HIGH:
 		return RTPREF_HIGH;
 	case ND_RA_FLAG_RTPREF_MEDIUM:
@@ -624,7 +638,7 @@ ipv6nd_rtpref(struct ra *rap)
 	case ND_RA_FLAG_RTPREF_LOW:
 		return RTPREF_LOW;
 	default:
-		logerrx("%s: impossible RA flag %x", __func__, rap->flags);
+		logerrx("%s: impossible RA flag %x", __func__, flags);
 		return RTPREF_INVALID;
 	}
 	/* NOTREACHED */
@@ -649,7 +663,7 @@ ipv6nd_sortrouters(struct dhcpcd_ctx *ctx)
 				continue;
 			if (!ra1->isreachable && ra2->reachable)
 				continue;
-			if (ipv6nd_rtpref(ra1) <= ipv6nd_rtpref(ra2))
+			if (ipv6nd_rtpref(ra1->flags) <= ipv6nd_rtpref(ra2->flags))
 				continue;
 			/* All things being equal, prefer older routers. */
 			/* We don't need to check time, becase newer
@@ -827,6 +841,7 @@ ipv6nd_removefreedrop_ra(struct ra *rap, int remove_ra, int drop_ra)
 	if (remove_ra)
 		TAILQ_REMOVE(rap->iface->ctx->ra_routers, rap, next);
 	ipv6_freedrop_addrs(&rap->addrs, drop_ra, NULL);
+	routeinfohead_free(&rap->routeinfos);
 	free(rap->data);
 	free(rap);
 }
@@ -1105,6 +1120,8 @@ ipv6nd_handlera(struct dhcpcd_ctx *ctx,
 	struct nd_opt_prefix_info pi;
 	struct nd_opt_mtu mtu;
 	struct nd_opt_rdnss rdnss;
+	struct nd_opt_ri ri;
+	struct routeinfo *routeinfo;
 	uint8_t *p;
 	struct ra *rap;
 	struct in6_addr pi_prefix;
@@ -1206,6 +1223,7 @@ ipv6nd_handlera(struct dhcpcd_ctx *ctx,
 		rap->from = from->sin6_addr;
 		strlcpy(rap->sfrom, sfrom, sizeof(rap->sfrom));
 		TAILQ_INIT(&rap->addrs);
+		TAILQ_INIT(&rap->routeinfos);
 		new_rap = true;
 		rap->isreachable = true;
 	} else
@@ -1502,6 +1520,51 @@ ipv6nd_handlera(struct dhcpcd_ctx *ctx,
 			    rdnss.nd_opt_rdnss_len > 1)
 				rap->hasdns = 1;
 			break;
+		case ND_OPT_RI:
+			if (ndo.nd_opt_len > 3) {
+				logmessage(loglevel, "%s: invalid route info option",
+				    ifp->name);
+				break;
+			}
+			memset(&ri, 0, sizeof(ri));
+			memcpy(&ri, p, olen); /* may be smaller than sizeof(ri), pad with zero */
+			if(ri.nd_opt_ri_prefixlen > 128) {
+				logmessage(loglevel, "%s: invalid route info prefix length",
+				    ifp->name);
+				break;
+			}
+
+			/* rfc4191 3.1 - RI for ::/0 applies to default route */
+			if(ri.nd_opt_ri_prefixlen == 0) {
+				rap->lifetime = ntohl(ri.nd_opt_ri_lifetime);
+
+				/* Update preference leaving other flags intact */
+				rap->flags = ((rap->flags & (~ (unsigned int)ND_RA_FLAG_RTPREF_MASK))
+					| ri.nd_opt_ri_flags_reserved) & 0xff;
+
+				break;
+			}
+
+			/* Update existing route info instead of rebuilding upon RA so that
+			previously announced but now absent routes can stay alive.  To kill a
+			route early, an RI with lifetime=0 needs to be received (rfc4191 3.1)*/
+			routeinfo = routeinfo_find(rap, &ri.nd_opt_ri_prefix, ri.nd_opt_ri_prefixlen);
+			if(routeinfo == NULL) {
+				/* add new route */
+				routeinfo = routeinfo_new(&ri.nd_opt_ri_prefix, ri.nd_opt_ri_prefixlen,
+				  ri.nd_opt_ri_flags_reserved,
+				  ntohl(ri.nd_opt_ri_lifetime));
+				if(routeinfo == NULL) {
+					break;
+				}
+				TAILQ_INSERT_TAIL(&rap->routeinfos, routeinfo, next);
+			} else {
+				/* Update the route info */
+				routeinfo->flags = ri.nd_opt_ri_flags_reserved;
+				routeinfo->lifetime = ntohl(ri.nd_opt_ri_lifetime);
+				routeinfo->acquired = rap->acquired;
+			}
+			break;
 		default:
 			continue;
 		}
@@ -1699,7 +1762,7 @@ ipv6nd_env(FILE *fp, const struct interface *ifp)
 			return -1;
 		if (efprintf(fp, "%s_hoplimit=%u", ndprefix, rap->hoplimit) == -1)
 			return -1;
-		pref = ipv6nd_rtpref(rap);
+		pref = ipv6nd_rtpref(rap->flags);
 		if (efprintf(fp, "%s_flags=%s%s%s%s%s", ndprefix,
 		    rap->flags & ND_RA_FLAG_MANAGED    ? "M" : "",
 		    rap->flags & ND_RA_FLAG_OTHER      ? "O" : "",
@@ -1804,6 +1867,7 @@ ipv6nd_expirera(void *arg)
 	uint32_t elapsed;
 	bool expired, valid;
 	struct ipv6_addr *ia;
+	struct routeinfo *routeinfo, *routeinfob;
 	size_t len, olen;
 	uint8_t *p;
 	struct nd_opt_hdr ndo;
@@ -1823,7 +1887,8 @@ ipv6nd_expirera(void *arg)
 		if (rap->iface != ifp || rap->expired)
 			continue;
 		valid = false;
-		if (rap->lifetime) {
+		/* lifetime may be set to infinite by rfc4191 route information */
+		if (rap->lifetime && rap->lifetime != ND6_INFINITE_LIFETIME) {
 			elapsed = (uint32_t)eloop_timespec_diff(&now,
 			    &rap->acquired, NULL);
 			if (elapsed >= rap->lifetime || rap->doexpire) {
@@ -1876,6 +1941,20 @@ ipv6nd_expirera(void *arg)
 				ltime = ia->prefix_vltime - elapsed;
 				if (next == 0 || ltime < next)
 					next = ltime;
+			}
+		}
+
+		/* Expire route information */
+		TAILQ_FOREACH_SAFE(routeinfo, &rap->routeinfos, next, routeinfob) {
+			if (routeinfo->lifetime == ND6_INFINITE_LIFETIME &&
+			    !rap->doexpire)
+				continue;
+			elapsed = (uint32_t)eloop_timespec_diff(&now,
+			    &routeinfo->acquired, NULL);
+			if (elapsed >= routeinfo->lifetime || rap->doexpire) {
+				logwarnx("%s: expired route %s",
+				    rap->iface->name, routeinfo->sprefix);
+				TAILQ_REMOVE(&rap->routeinfos, routeinfo, next);
 			}
 		}
 
@@ -2134,4 +2213,54 @@ ipv6nd_startrs(struct interface *ifp)
 	    ifp->name, (float)delay / MSEC_PER_SEC);
 	eloop_timeout_add_msec(ifp->ctx->eloop, delay, ipv6nd_startrs1, ifp);
 	return;
+}
+
+struct routeinfo *routeinfo_new(const struct in6_addr *prefix, uint8_t prefixlength, uint8_t flags, uint32_t lifetime)
+{
+	struct routeinfo *ri;
+	char buf[INET6_ADDRSTRLEN];
+	const char *p;
+
+	ri = calloc(1, sizeof(struct routeinfo));
+	if (ri == NULL)
+		return NULL;
+
+	memcpy(&ri->prefix, prefix, sizeof(ri->prefix));
+	ri->prefixlength = prefixlength;
+	ri->flags = flags;
+	ri->lifetime = lifetime;
+	clock_gettime(CLOCK_MONOTONIC, &ri->acquired);
+
+	p = inet_ntop(AF_INET6, prefix, buf, sizeof(buf));
+	if (p)
+		snprintf(ri->sprefix,
+			sizeof(ri->sprefix),
+			"%s/%d",
+			p, prefixlength);
+	else
+		ri->sprefix[0] = '\0';
+
+	return ri;
+}
+
+struct routeinfo *routeinfo_find(struct ra *rap, const struct in6_addr *prefix, uint8_t prefixlength)
+{
+	struct routeinfo *ri;
+
+	TAILQ_FOREACH(ri, &rap->routeinfos, next) {
+		if (ri->prefixlength == prefixlength &&
+		    IN6_ARE_ADDR_EQUAL(&ri->prefix, prefix))
+			return ri;
+	}
+	return NULL;
+}
+
+void routeinfohead_free(struct routeinfohead *head)
+{
+	struct routeinfo *ri;
+
+	while ((ri = TAILQ_FIRST(head))) {
+		TAILQ_REMOVE(head, ri, next);
+		free(ri);
+	}
 }

--- a/src/ipv6nd.h
+++ b/src/ipv6nd.h
@@ -41,10 +41,10 @@
 struct routeinfo {
 	TAILQ_ENTRY(routeinfo) next;
 	struct in6_addr prefix;
+	uint8_t prefix_len;
 	uint32_t lifetime;
-	struct timespec acquired;
 	uint8_t flags;
-	uint8_t prefixlength;
+	struct timespec acquired;
 	char sprefix[INET6_ADDRSTRLEN];
 };
 
@@ -66,7 +66,7 @@ struct ra {
 	uint32_t mtu;
 	uint8_t hoplimit;
 	struct ipv6_addrhead addrs;
-	struct routeinfohead routeinfos;
+	struct routeinfohead rinfos;
 	bool hasdns;
 	bool expired;
 	bool willexpire;
@@ -142,9 +142,6 @@ void ipv6nd_advertise(struct ipv6_addr *);
 void ipv6nd_startexpire(struct interface *);
 void ipv6nd_drop(struct interface *);
 void ipv6nd_neighbour(struct dhcpcd_ctx *, struct in6_addr *, bool);
-struct routeinfo *routeinfo_new(const struct in6_addr *, uint8_t, uint8_t, uint32_t);
-struct routeinfo *routeinfo_find(struct ra *, const struct in6_addr *, uint8_t);
-void routeinfohead_free(struct routeinfohead *);
 #endif /* INET6 */
 
 #endif /* IPV6ND_H */

--- a/src/ipv6nd.h
+++ b/src/ipv6nd.h
@@ -37,6 +37,20 @@
 #include "dhcpcd.h"
 #include "ipv6.h"
 
+/* rfc4191 */
+struct routeinfo {
+	TAILQ_ENTRY(routeinfo) next;
+	struct in6_addr prefix;
+	uint32_t lifetime;
+	struct timespec acquired;
+	uint8_t flags;
+	uint8_t prefixlength;
+	char sprefix[INET6_ADDRSTRLEN];
+};
+
+TAILQ_HEAD(routeinfohead, routeinfo);
+
+
 struct ra {
 	TAILQ_ENTRY(ra) next;
 	struct interface *iface;
@@ -45,13 +59,14 @@ struct ra {
 	uint8_t *data;
 	size_t data_len;
 	struct timespec acquired;
-	unsigned char flags;
+	uint8_t flags;
 	uint32_t lifetime;
 	uint32_t reachable;
 	uint32_t retrans;
 	uint32_t mtu;
 	uint8_t hoplimit;
 	struct ipv6_addrhead addrs;
+	struct routeinfohead routeinfos;
 	bool hasdns;
 	bool expired;
 	bool willexpire;
@@ -105,7 +120,7 @@ int ipv6nd_open(bool);
 int ipv6nd_openif(struct interface *);
 #endif
 void ipv6nd_recvmsg(struct dhcpcd_ctx *, struct msghdr *);
-int ipv6nd_rtpref(struct ra *);
+int ipv6nd_rtpref(uint8_t);
 void ipv6nd_printoptions(const struct dhcpcd_ctx *,
     const struct dhcp_opt *, size_t);
 void ipv6nd_startrs(struct interface *);
@@ -127,6 +142,9 @@ void ipv6nd_advertise(struct ipv6_addr *);
 void ipv6nd_startexpire(struct interface *);
 void ipv6nd_drop(struct interface *);
 void ipv6nd_neighbour(struct dhcpcd_ctx *, struct in6_addr *, bool);
+struct routeinfo *routeinfo_new(const struct in6_addr *, uint8_t, uint8_t, uint32_t);
+struct routeinfo *routeinfo_find(struct ra *, const struct in6_addr *, uint8_t);
+void routeinfohead_free(struct routeinfohead *);
 #endif /* INET6 */
 
 #endif /* IPV6ND_H */

--- a/src/sa.c
+++ b/src/sa.c
@@ -300,11 +300,39 @@ sa_toprefix(const struct sockaddr *sa)
 	return prefix;
 }
 
+void
+ipbytes_fromprefix(uint8_t *ap, int prefix, int max_prefix)
+{
+	int bytes, bits, i;
+
+	bytes = prefix / NBBY;
+	bits = prefix % NBBY;
+
+	for (i = 0; i < bytes; i++)
+		*ap++ = 0xff;
+	if (bits) {
+		uint8_t a;
+
+		a = 0xff;
+		a  = (uint8_t)(a << (8 - bits));
+		*ap++ = a;
+	}
+	bytes = (max_prefix - prefix) / NBBY;
+	for (i = 0; i < bytes; i++)
+		*ap++ = 0x00;
+}
+
+void
+in6_addr_fromprefix(struct in6_addr *addr, int prefix)
+{
+	ipbytes_fromprefix((uint8_t *)addr, prefix, 128);
+}
+
 int
 sa_fromprefix(struct sockaddr *sa, int prefix)
 {
 	uint8_t *ap;
-	int max_prefix, bytes, bits, i;
+	int max_prefix;
 
 	switch (sa->sa_family) {
 #ifdef INET
@@ -328,22 +356,8 @@ sa_fromprefix(struct sockaddr *sa, int prefix)
 		return -1;
 	}
 
-	bytes = prefix / NBBY;
-	bits = prefix % NBBY;
-
 	ap = (uint8_t *)sa + sa_addroffset(sa);
-	for (i = 0; i < bytes; i++)
-		*ap++ = 0xff;
-	if (bits) {
-		uint8_t a;
-
-		a = 0xff;
-		a  = (uint8_t)(a << (8 - bits));
-		*ap++ = a;
-	}
-	bytes = (max_prefix - prefix) / NBBY;
-	for (i = 0; i < bytes; i++)
-		*ap++ = 0x00;
+	ipbytes_fromprefix(ap, prefix, max_prefix);
 
 #ifndef NDEBUG
 	/* Ensure the calculation is correct */

--- a/src/sa.c
+++ b/src/sa.c
@@ -300,7 +300,7 @@ sa_toprefix(const struct sockaddr *sa)
 	return prefix;
 }
 
-void
+static void
 ipbytes_fromprefix(uint8_t *ap, int prefix, int max_prefix)
 {
 	int bytes, bits, i;

--- a/src/sa.h
+++ b/src/sa.h
@@ -67,7 +67,6 @@ bool sa_is_loopback(const struct sockaddr *);
 void *sa_toaddr(struct sockaddr *);
 int sa_toprefix(const struct sockaddr *);
 int sa_fromprefix(struct sockaddr *, int);
-void ipbytes_fromprefix(uint8_t *, int, int);
 void in6_addr_fromprefix(struct in6_addr *, int);
 const char *sa_addrtop(const struct sockaddr *, char *, socklen_t);
 int sa_cmp(const struct sockaddr *, const struct sockaddr *);

--- a/src/sa.h
+++ b/src/sa.h
@@ -67,6 +67,8 @@ bool sa_is_loopback(const struct sockaddr *);
 void *sa_toaddr(struct sockaddr *);
 int sa_toprefix(const struct sockaddr *);
 int sa_fromprefix(struct sockaddr *, int);
+void ipbytes_fromprefix(uint8_t *, int, int);
+void in6_addr_fromprefix(struct in6_addr *, int);
 const char *sa_addrtop(const struct sockaddr *, char *, socklen_t);
 int sa_cmp(const struct sockaddr *, const struct sockaddr *);
 void sa_in_init(struct sockaddr *, const struct in_addr *);


### PR DESCRIPTION
Resolves issue #102.

Implement RFC4191 support for Route Information options in Router Advertisements.  This option allows a router to provide routes for a specific prefix instead of only providing default routes.

My use case is that I have a ULA network with a VPN router and no IPv6 internet access.  Using this router as the default route does not work well because the host then thinks it can reach the Internet.  By instead advertising a route just for the ULA prefix hosts will immediately know they cannot reach the Internet through this router.

I've tested this PR in a VM in this exact configuration and it seems to work quite well.  I changed the radvd config on the fly to remove and add the route and it behaved as expected.
