### PR TITLE
Define the Azure Endpoint and other site-specific options

### DIFF
--- a/src/dhcpcd-definitions.conf
+++ b/src/dhcpcd-definitions.conf
@@ -333,7 +333,16 @@ encap 255	flag			global
 
 # Options 222 and 223 are unused, RFC3942
 
-# Options 224-254 are reserved for Private Use
+# Options 224-254 are reserved for site-specific use by RFC3942.
+# For historical reasons, some of these options have well known
+# definitions and we implement those definitions here.
+# Site-specific options are designed to be configured by the end user
+# if needed and any configuration here may change in the future.
+
+# Option 245 is an IANA assigned private number used by Azure DHCP
+# servers to provide the IPv4 address of the Azure WireServer endpoint
+# to virtual machines hosted in Azure.
+define 245	ipaddress		azureendpoint
 
 # Option 249 is an IANA assigned private number used by Windows DHCP servers
 # to provide the exact same information as option 121, classless static routes
@@ -343,6 +352,38 @@ define 249	rfc3442			ms_classless_static_routes
 # Option 252 which is commonly used by major browsers.
 # Apparently the code was assigned by agreement of the DHC working group chair.
 define 252	uri			wpad_url
+
+define 224	binhex			site_specific_224
+define 225	binhex			site_specific_225
+define 226	binhex			site_specific_226
+define 227	binhex			site_specific_227
+define 228	binhex			site_specific_228
+define 229	binhex			site_specific_229
+define 230	binhex			site_specific_230
+define 231	binhex			site_specific_231
+define 232	binhex			site_specific_232
+define 233	binhex			site_specific_233
+define 234	binhex			site_specific_234
+define 235	binhex			site_specific_235
+define 236	binhex			site_specific_236
+define 237	binhex			site_specific_237
+define 238	binhex			site_specific_238
+define 239	binhex			site_specific_239
+define 240	binhex			site_specific_240
+define 241	binhex			site_specific_241
+define 242	binhex			site_specific_242
+define 243	binhex			site_specific_243
+define 244	binhex			site_specific_244
+#Option 245 has a custom definition above.
+define 246	binhex			site_specific_246
+define 247	binhex			site_specific_247
+define 248	binhex			site_specific_248
+#Option 249 has a custom definition above.
+define 250	binhex			site_specific_250
+define 251	binhex			site_specific_251
+#Option 252 has a custom definition above.
+define 253	binhex			site_specific_253
+define 254	binhex			site_specific_254
 
 # Option 255 End
 


### PR DESCRIPTION
Added the azureendpoint site-specific option as an ipaddress definition to make it easier for Azure VMs using dhcpcd to get their WireServer endpoint address.

Added binhex definitions for all otherwise undefined site-specific options so that site-specific hooks can use them.