### PR TITLE
dhcpcd: Respect IPV6_PREFERRED_ONLY flag regardless of state

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3207,8 +3207,8 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 
 	if (has_option_mask(ifo->requestmask, DHO_IPV6_PREFERRED_ONLY)) {
 		if (get_option_uint32(ifp->ctx, &v6only_time, bootp, bootp_len,
-		    DHO_IPV6_PREFERRED_ONLY) == 0 &&
-		    (state->state == DHS_DISCOVER || state->state == DHS_REBOOT))
+		    DHO_IPV6_PREFERRED_ONLY) == 0 && (state->state == DHS_DISCOVER ||
+		    state->state == DHS_REBOOT || state->state == DHS_NONE))
 		{
 			char v6msg[128];
 


### PR DESCRIPTION
Current IPv6_PREFERRED_ONLY (option 108) handling code is only effective when current state is DHS_DISCOVER or DHS_REBOOT. However the assumption that we'll only receive OFFER and ACK with option 108 in those two states is not true. Particularly, when we receive multiple ACKs upon our REQUEST, the first ACK will trigger the use_v6only code path and dhcp_drop() us into DHS_NONE state, therefore the option 108 on second ACK won't be handled correctly and we'll bind to the lease incorrectly.

DHS_NONE is not the only possible state, considering the corner cases of server configuration change and multiple servers. Thus we should just remove the state check here.