### PR TITLE
Fix time_offset to be int to match RFC-2132

### DIFF
--- a/src/dhcpcd-definitions.conf
+++ b/src/dhcpcd-definitions.conf
@@ -12,7 +12,7 @@ define 1	request ipaddress	subnet_mask
 # RFC3442 states that the CSR has to come before all other routes
 # For completeness we also specify static routes then routers
 define 121	rfc3442			classless_static_routes
-define 2	uint32			time_offset
+define 2	int32			time_offset
 define 3	request array ipaddress	routers
 define 4	array ipaddress		time_servers
 define 5	array ipaddress		ien116_name_servers


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc2132#section-3.4

time_offset (dhcp v4 option 2) should be int32, not uint32, as it can indicate a time offset east (positive) or west (negative) of zero meridian.

Fixes issue #318 