### PR TITLE
hooks/30-hostname: Exit with 0 if setting hostname is not needed

### DIFF
--- a/hooks/30-hostname.in
+++ b/hooks/30-hostname.in
@@ -118,7 +118,7 @@ set_hostname()
 	*)					hshort=true;;
 	esac
 
-	need_hostname || return
+	need_hostname || return 0
 
 	if [ -n "$new_fqdn" ]; then
 		if ${hfqdn} || ! ${hshort}; then


### PR DESCRIPTION
If the hostname is already set before dhcpcd is started, `need_hostname` will hit the "No old hostname" case and will call `false` to return 1. `set_hostname` will return with the same return value. Then `30-hostname` will exit with the same exit value:

```
dhcpcd-10.0.6 starting
dev: loaded udev
DUID 00:03:00:01:3c:97:0e:e9:32:3c
enp0s25: IAID 0e:e9:32:3c
enp0s25: soliciting a DHCP lease
enp0s25: offered 192.168.3.61 from 192.168.1.7
enp0s25: ignoring offer of 192.168.3.61 from 192.168.1.8
enp0s25: probing address 192.168.3.61/20
enp0s25: leased 192.168.3.61 for 3600 seconds
enp0s25: adding route to 192.168.0.0/20
enp0s25: adding default route via 192.168.1.1
script_status: /usr/lib/dhcpcd/dhcpcd-run-hooks: WEXITSTATUS 1
exiting due to oneshot
dhcpcd exited
```

Return with value 0 in case setting the hostname is not needed.

Bug-Ubuntu: https://launchpad.net/bugs/2064926