### PR TITLE
DHCP: Handle option 108 correctly when receiving 0.0.0.0 OFFER

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -774,7 +774,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 	}
 
 	if (ifo->options & DHCPCD_BROADCAST &&
-	    bootp->ciaddr == 0 &&
+	    bootp->ciaddr == INADDR_ANY &&
 	    type != DHCP_DECLINE &&
 	    type != DHCP_RELEASE)
 		bootp->flags = htons(BROADCAST_FLAG);
@@ -1651,7 +1651,7 @@ dhcp_makeudppacket(size_t *sz, const uint8_t *data, size_t length,
 
 	ip->ip_p = IPPROTO_UDP;
 	ip->ip_src.s_addr = source.s_addr;
-	if (dest.s_addr == 0)
+	if (dest.s_addr == INADDR_ANY)
 		ip->ip_dst.s_addr = INADDR_BROADCAST;
 	else
 		ip->ip_dst.s_addr = dest.s_addr;
@@ -3232,7 +3232,7 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	}
 
 	/* DHCP Auto-Configure, RFC 2563 */
-	if (type == DHCP_OFFER && bootp->yiaddr == 0) {
+	if (type == DHCP_OFFER && bootp->yiaddr == INADDR_ANY) {
 		LOGDHCP(LOG_WARNING, "no address offered");
 		if ((msg = get_option_string(ifp->ctx,
 		    bootp, bootp_len, DHO_MESSAGE)))
@@ -3282,7 +3282,7 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 
 	/* No hints as what to do with no address?
 	 * All we can do is continue. */
-	if (type == DHCP_OFFER && bootp->yiaddr == 0)
+	if (type == DHCP_OFFER && bootp->yiaddr == INADDR_ANY)
 		return;
 
 	/* Ensure that the address offered is valid */

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3215,7 +3215,8 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 
 	if (has_option_mask(ifo->requestmask, DHO_IPV6_PREFERRED_ONLY)) {
 		if (get_option_uint32(ifp->ctx, &v6only_time, bootp, bootp_len,
-		    DHO_IPV6_PREFERRED_ONLY) == 0 && (state->state == DHS_DISCOVER ||
+		    DHO_IPV6_PREFERRED_ONLY) == 0 &&
+		    (state->state == DHS_DISCOVER ||
 		    state->state == DHS_REBOOT || state->state == DHS_NONE))
 		{
 			char v6msg[128];
@@ -3232,6 +3233,7 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 
 	/* DHCP Auto-Configure, RFC 2563 */
 	if (type == DHCP_OFFER && bootp->yiaddr == 0) {
+		LOGDHCP(LOG_WARNING, "no address offered");
 		if ((msg = get_option_string(ifp->ctx,
 		    bootp, bootp_len, DHO_MESSAGE)))
 		{
@@ -3279,11 +3281,9 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	}
 
 	/* No hints as what to do with no address?
-	 * all we can do is log it and continue. */
-	if (type == DHCP_OFFER && bootp->yiaddr == 0) {
-		LOGDHCP(LOG_WARNING, "no address given");
+	 * All we can do is continue. */
+	if (type == DHCP_OFFER && bootp->yiaddr == 0)
 		return;
-	}
 
 	/* Ensure that the address offered is valid */
 	if ((type == 0 || type == DHCP_OFFER || type == DHCP_ACK) &&

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -2989,7 +2989,7 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	struct dhcp_state *state = D_STATE(ifp);
 	struct if_options *ifo = ifp->options;
 	struct dhcp_lease *lease = &state->lease;
-	uint8_t type, tmp, ipv4llonly = 0;
+	uint8_t type, tmp;
 	struct in_addr addr;
 	unsigned int i;
 	char *msg;
@@ -3240,11 +3240,11 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 		}
 #ifdef IPV4LL
 		if (state->state == DHS_DISCOVER &&
-		    get_option_uint8(ifp->ctx, &ipv4llonly, bootp, bootp_len,
+		    get_option_uint8(ifp->ctx, &tmp, bootp, bootp_len,
 		    DHO_AUTOCONFIGURE) == 0)
 		{
 			has_auto_conf = true;
-			switch (ipv4llonly) {
+			switch (tmp) {
 			case 0:
 				LOGDHCP(LOG_WARNING, "IPv4LL disabled from");
 				ipv4ll_drop(ifp);

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3262,12 +3262,12 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 				    ifp->name, tmp);
 				break;
 			}
-			eloop_timeout_delete(ifp->ctx->eloop, NULL, ifp);
-			eloop_timeout_add_sec(ifp->ctx->eloop,
-			    use_v6only ? v6only_time : DHCP_MAX,
-			    dhcp_discover, ifp);
 		}
 #endif
+		eloop_timeout_delete(ifp->ctx->eloop, NULL, ifp);
+		eloop_timeout_add_sec(ifp->ctx->eloop,
+		    use_v6only ? v6only_time : DHCP_MAX,
+		    dhcp_discover, ifp);
 		return;
 	}
 


### PR DESCRIPTION
According to RFC8925 section 3.3.1, when the server supports both option 108 (IPv6-Only Preferred) and option 116 (Auto-Configure), and the client only sends IPv6-Only Preferred option, then the server SHOULD return 0.0.0.0 as the offered address, and not setting the Auto-Configure option.

However, in our current client code, the IPv6-Only Preferred option in a 0.0.0.0 OFFER is only handled correctly when the Auto-Configure option is present. This patch fixes this issue.