### PR TITLE
DHCP: No longer set interface mtu

### DIFF
--- a/src/dhcp-common.h
+++ b/src/dhcp-common.h
@@ -46,11 +46,6 @@
 #define NS_MAXLABEL MAXLABEL
 #endif
 
-/* Max MTU - defines dhcp option length */
-#define	IP_UDP_SIZE		  28
-#define	MTU_MAX			1500 - IP_UDP_SIZE
-#define	MTU_MIN			 576 + IP_UDP_SIZE
-
 #define	OT_REQUEST		(1 << 0)
 #define	OT_UINT8		(1 << 1)
 #define	OT_INT8			(1 << 2)

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -1218,7 +1218,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 			if (p == NULL)
 				break;
 			ifo->mtu = (unsigned int)strtou(p, NULL, 0,
-			    MTU_MIN, MTU_MAX, &e);
+			    IPV4_MMTU, UINT_MAX, &e);
 			if (e) {
 				logerrx("invalid MTU %s", p);
 				return -1;

--- a/src/if.c
+++ b/src/if.c
@@ -852,27 +852,18 @@ if_loopback(struct dhcpcd_ctx *ctx)
 }
 
 int
-if_domtu(const struct interface *ifp, short int mtu)
+if_getmtu(const struct interface *ifp)
 {
-	int r;
-	struct ifreq ifr;
-
 #ifdef __sun
-	if (mtu == 0)
-		return if_mtu_os(ifp);
-#endif
+	return if_mtu_os(ifp);
+#else
+	struct ifreq ifr = { .ifr_mtu = 0 };
 
-	memset(&ifr, 0, sizeof(ifr));
 	strlcpy(ifr.ifr_name, ifp->name, sizeof(ifr.ifr_name));
-	ifr.ifr_mtu = mtu;
-	if (mtu != 0)
-		r = if_ioctl(ifp->ctx, SIOCSIFMTU, &ifr, sizeof(ifr));
-	else
-		r = pioctl(ifp->ctx, SIOCGIFMTU, &ifr, sizeof(ifr));
-
-	if (r == -1)
+	if (pioctl(ifp->ctx, SIOCGIFMTU, &ifr, sizeof(ifr)) == -1)
 		return -1;
 	return ifr.ifr_mtu;
+#endif
 }
 
 #ifdef ALIAS_ADDR

--- a/src/if.h
+++ b/src/if.h
@@ -178,9 +178,7 @@ struct interface *if_find(struct if_head *, const char *);
 struct interface *if_findindex(struct if_head *, unsigned int);
 struct interface *if_loopback(struct dhcpcd_ctx *);
 void if_free(struct interface *);
-int if_domtu(const struct interface *, short int);
-#define if_getmtu(ifp) if_domtu((ifp), 0)
-#define if_setmtu(ifp, mtu) if_domtu((ifp), (mtu))
+int if_getmtu(const struct interface *);
 int if_carrier(struct interface *, const void *);
 bool if_roaming(struct interface *);
 

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -58,6 +58,10 @@
     (((uint32_t)(A) & 0x000000ff) << 24))
 #endif /* BYTE_ORDER */
 
+#ifndef IPV4_MMTU
+#define IPV4_MMTU 68
+#endif
+
 #ifdef __sun
    /* Solaris lacks these defines.
     * While it supports DaD, to seems to only expose IFF_DUPLICATE


### PR DESCRIPTION
We've been enforcing an interface MTU that is slightly larger than the minimum for some time.
Instead, log an error than the MTU is smaller than the minimum to send a BOOTP message.

The DHCP MTU is only used when adding routes as setting the interface MTU can cause a PHY reset which is bad.

Fixes #345