### PR TITLE
Fix dhcpcd sending wrong message when RENEWING/REBINDING

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -704,6 +704,10 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 void
 rt_build(struct dhcpcd_ctx *ctx, int af)
 {
+	if (!(ctx->options & DHCPCD_CONFIGURE)) {
+		return;
+	}
+
 	rb_tree_t routes, added, kroutes;
 	struct rt *rt, *rtn;
 	unsigned long long o;


### PR DESCRIPTION
When RENEWING/REBINDING, the DHCP client should send messages with ciaddr set and requested-ip unset. However when dhcpcd 10 is configured with --noconfigure, the messages sent are the opposite: ciaddr unset and requested-ip set - these messages are for INIT-REBOOT, not RENEWING or REBINDING.

The reason for it is that when --noconfigure is enabled, dhcpcd won't setup the state->addr property of the interface when the lease is bound. When dhcpcd renews or rebinds the lease later, it needs state->addr to be set to correctly configure ciaddr and requested-ip. Since state->addr is NULL, dhcpcd sends wrong messages (for the detail see github.com/NetworkConfiguration/dhcpcd/issues/355).

This patch fixes this by also setting up state->addr with ipv4_applyaddr() when --noconfigure is enabled. Note that this function also configure the IPv4 address and build routes in the system, so we need to disable these in the function.

Change-Id: I94bfffd95b62066995bd436d3b8bf185eafda398