### PR TITLE
Fix dhcpcd sending wrong message when RENEWING/REBINDING

### DIFF
--- a/src/ipv4ll.c
+++ b/src/ipv4ll.c
@@ -294,8 +294,7 @@ ipv4ll_defend_failed(struct interface *ifp)
 	struct ipv4ll_state *state = IPV4LL_STATE(ifp);
 
 	ipv4ll_freearp(ifp);
-	if (ifp->options->options & DHCPCD_CONFIGURE)
-		ipv4_deladdr(state->addr, 1);
+	ipv4_deladdr(state->addr, 1);
 	state->addr = NULL;
 	rt_build(ifp->ctx, AF_INET);
 	script_runreason(ifp, "IPV4LL");
@@ -388,8 +387,7 @@ ipv4ll_start(void *arg)
 	if (ia != NULL && ia->addr_flags & IN_IFF_DUPLICATED) {
 		state->pickedaddr = ia->addr; /* So it's not picked again. */
 		repick = true;
-		if (ifp->options->options & DHCPCD_CONFIGURE)
-			ipv4_deladdr(ia, 0);
+		ipv4_deladdr(ia, 0);
 		ia = NULL;
 	}
 #endif
@@ -464,8 +462,7 @@ ipv4ll_drop(struct interface *ifp)
 	if (state) {
 		state->running = false;
 		if (state->addr != NULL) {
-			if (ifp->options->options & DHCPCD_CONFIGURE)
-				ipv4_deladdr(state->addr, 1);
+			ipv4_deladdr(state->addr, 1);
 			state->addr = NULL;
 			dropped = true;
 		}
@@ -477,8 +474,7 @@ ipv4ll_drop(struct interface *ifp)
 
 		TAILQ_FOREACH_SAFE(ia, &istate->addrs, next, ian) {
 			if (IN_LINKLOCAL(ntohl(ia->addr.s_addr))) {
-				if (ifp->options->options & DHCPCD_CONFIGURE)
-					ipv4_deladdr(ia, 0);
+				ipv4_deladdr(ia, 0);
 				dropped = true;
 			}
 		}
@@ -570,8 +566,7 @@ ipv4ll_handleifa(int cmd, struct ipv4_addr *ia, pid_t pid)
 	else if (ia->addr_flags & IN_IFF_DUPLICATED) {
 		logerrx("%s: DAD detected %s", ifp->name, ia->saddr);
 		ipv4ll_freearp(ifp);
-		if (ifp->options->options & DHCPCD_CONFIGURE)
-			ipv4_deladdr(ia, 1);
+		ipv4_deladdr(ia, 1);
 		state->addr = NULL;
 		rt_build(ifp->ctx, AF_INET);
 		ipv4ll_found(ifp);

--- a/src/route.c
+++ b/src/route.c
@@ -704,6 +704,10 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 void
 rt_build(struct dhcpcd_ctx *ctx, int af)
 {
+	if (!(ctx->options & DHCPCD_CONFIGURE)) {
+		return;
+	}
+
 	rb_tree_t routes, added, kroutes;
 	struct rt *rt, *rtn;
 	unsigned long long o;


### PR DESCRIPTION
When RENEWING/REBINDING, the DHCP client should send messages with ciaddr set and requested-ip unset. However when dhcpcd 10 is configured with --noconfigure, the messages sent are the opposite: ciaddr unset and requested-ip set - these messages are for INIT-REBOOT, not RENEWING or REBINDING.

The reason for it is that when --noconfigure is enabled, dhcpcd won't setup the state->addr property of the interface when the lease is bound. When dhcpcd renews or rebinds the lease later, it needs state->addr to be set to correctly configure ciaddr and requested-ip. Since state->addr is NULL, dhcpcd sends wrong messages (for the detail see github.com/NetworkConfiguration/dhcpcd/issues/355).

This patch fixes this by also setting up state->addr with ipv4_applyaddr() when --noconfigure is enabled. Note that this function also configure the IPv4 address and build routes in the system, so we need to disable these in the function.