### PR TITLE
dhcpcd: stdout output sometimes empty when redirected to a file

### DIFF
--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -136,6 +136,7 @@ dhcp_print_option_encoding(const struct dhcp_opt *opt, int cols)
 	if (opt->type & OT_NOREQ)
 		printf(" norequest");
 	putchar('\n');
+	fflush(stdout);
 }
 
 struct dhcp_opt *

--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -2719,6 +2719,7 @@ exit1:
 	eloop_free(ctx.eloop);
 	logclose();
 	free(ctx.logfile);
+	fflush(stdout);
 	free(ctx.ctl_buf);
 #ifdef SETPROCTITLE_H
 	setproctitle_fini();

--- a/src/script.c
+++ b/src/script.c
@@ -738,6 +738,7 @@ script_dump(const char *env, size_t len)
 			env += 4;
 		printf("%s\n", env);
 	}
+	fflush(stdout);
 	return 0;
 }
 


### PR DESCRIPTION
Running dhpcd --dumplease with input from stdin and redirecting stdout to a file outputs nothing to the output. The reason is that printf / fprintf is used to write the output but it is not explicitly flushed when done, or before exiting, and stdout to files is fully buffered by default while stdout to terminals is line buffered by default.

This adds calls to fflush() at the end of dhcp_print_option_encoding() and script_dump(), plus one just before exiting dhcpcd.