### PR TITLE
DHCP: Handling multiple vendor sub-options with the same code number

### DIFF
--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -874,18 +874,20 @@ dhcp_envoption(struct dhcpcd_ctx *ctx, FILE *fp, const char *prefix,
     const uint8_t *, size_t, struct dhcp_opt **),
     const uint8_t *od, size_t ol)
 {
-	size_t i, eos, eol;
+	size_t i, eos, eol, buflen, tol;
 	ssize_t eo;
 	unsigned int eoc;
-	const uint8_t *eod;
+	const uint8_t *eod, *tod;
 	int ov;
 	struct dhcp_opt *eopt, *oopt;
 	char *pfx;
+	uint8_t *buf, *nbuf;
 
 	/* If no embedded or encapsulated options, it's easy */
 	if (opt->embopts_len == 0 && opt->encopts_len == 0) {
 		if (opt->type & OT_RESERVED)
 			return;
+		ol = dhcp_optlen(opt, ol);
 		if (print_option(fp, prefix, opt, 1, od, ol, ifname) == -1)
 			logerr("%s: %s %d", ifname, __func__, opt->option);
 		return;
@@ -943,7 +945,6 @@ dhcp_envoption(struct dhcpcd_ctx *ctx, FILE *fp, const char *prefix,
 		od += (size_t)eo;
 		ol -= (size_t)eo;
 	}
-
 	/* Enumerate our encapsulated options */
 	if (opt->encopts_len && ol > 0) {
 		/* Zero any option indexes
@@ -961,10 +962,17 @@ dhcp_envoption(struct dhcpcd_ctx *ctx, FILE *fp, const char *prefix,
 			}
 		}
 
-		while ((eod = dgetopt(ctx, &eos, &eoc, &eol, od, ol, &oopt))) {
-			for (i = 0, eopt = opt->encopts;
-			    i < opt->encopts_len;
-			    i++, eopt++)
+		tod = od;
+		tol = ol;
+		for (i = 0, eopt = opt->encopts;
+		    i < opt->encopts_len;
+		    i++, eopt++)
+		{
+			buflen = 0;
+			buf = NULL;
+			for (od = tod, ol = tol;
+			     eod = dgetopt(ctx, &eos, &eoc, &eol, od, ol, &oopt);
+			     od += eos + eol, ol -= eos + eol)
 			{
 				if (eopt->option != eoc)
 					continue;
@@ -972,13 +980,28 @@ dhcp_envoption(struct dhcpcd_ctx *ctx, FILE *fp, const char *prefix,
 					if (oopt == NULL)
 						/* Report error? */
 						continue;
+					dhcp_envoption(ctx, fp, pfx, ifname, oopt,
+					               dgetopt, eod, eol);
+				} else {
+					eol = dhcp_optlen(eopt, eol);
+					nbuf = realloc(buf, eol + buflen);
+					if (nbuf == NULL) {
+						free(buf);
+						goto out;
+					}
+					buf = nbuf;
+					memcpy(buf + buflen, eod, eol);
+					buflen += eol;
 				}
-				dhcp_envoption(ctx, fp, pfx, ifname,
-				    eopt->type & OT_OPTION ? oopt:eopt,
-				    dgetopt, eod, eol);
 			}
-			od += eos + eol;
-			ol -= eos + eol;
+			if (!(eopt->type & OT_OPTION)) {
+				if (print_option(fp, pfx, eopt, 1, buf, buflen,
+						 ifname) == -1)
+					logerr("%s: %s %d.%d/%zu",
+					       ifname, __func__,
+					       opt->option, eopt->option, i);
+				free(buf);
+		        }
 		}
 	}
 

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -336,6 +336,66 @@ dhcp6_makevendor(void *data, const struct interface *ifp)
 	return sizeof(o) + len;
 }
 
+// DHCPv6 Option 17 (Vendor-Specific Information Option)
+static size_t
+dhcp6_makevendoropts(void *data, const struct interface *ifp, uint32_t en)
+{
+	const struct if_options *ifo;
+	size_t len, vlen, i;
+	uint8_t *p;
+	const struct vsio6 *vsio6;
+	struct dhcp6_option o;
+
+	ifo = ifp->options;
+	len = sizeof(uint32_t); /* IANA PEN */
+	vlen = 0;
+
+	for (i = 0, vsio6 = ifo->vsio6; i < ifo->vsio6_len; 
+		i++, vsio6++) {
+			if (vsio6->en != en)
+				continue;
+			vlen += 2 * sizeof(uint16_t) + vsio6->len;
+		}
+
+	len += vlen;
+	
+	if (len > UINT16_MAX) {
+		logerrx("%s: DHCPv6 Vendor-Specific Information Option too big", ifp->name);
+		return 0;
+	}
+
+	if (data != NULL) {
+		uint32_t pen;
+		uint16_t opt;
+		uint16_t hvlen;
+
+		p = data;
+		o.code = htons(D6_OPTION_VENDOR_OPTS);
+		o.len = htons((uint16_t)len);
+		memcpy(p, &o, sizeof(o));
+		p += sizeof(o);
+		pen = htonl(en);
+		memcpy(p, &pen, sizeof(pen));
+		p += sizeof(pen);
+
+		for (i = 0, vsio6 = ifo->vsio6; i < ifo->vsio6_len;
+			i++, vsio6++) {
+				if (vsio6->en != en)
+					continue;
+				opt = htons((uint16_t)vsio6->opt);
+				memcpy(p, &opt, sizeof(opt));
+				p += sizeof(opt);
+				hvlen = htons((uint16_t)vsio6->len);
+				memcpy(p, &hvlen, sizeof(hvlen));
+				p += sizeof(hvlen);
+				memcpy(p, vsio6->data, vsio6->len);
+				p += vsio6->len;
+			}
+		}
+
+	return sizeof(o) + len;
+}
+
 static void *
 dhcp6_findoption(void *data, size_t data_len, uint16_t code, uint16_t *len)
 {
@@ -803,6 +863,10 @@ dhcp6_makemessage(struct interface *ifp)
 		len += dhcp6_makeuser(NULL, ifp);
 	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
 		len += dhcp6_makevendor(NULL, ifp);
+	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_OPTS)) {
+		for (size_t j = 0; j < ifo->vsio6_ent_nums_len; j++)
+			len += dhcp6_makevendoropts(NULL, ifp, ifo->vsio6_ent_nums[j]);
+	}
 
 	/* IA */
 	m = NULL;
@@ -1123,6 +1187,10 @@ dhcp6_makemessage(struct interface *ifp)
 		p += dhcp6_makeuser(p, ifp);
 	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
 		p += dhcp6_makevendor(p, ifp);
+	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_OPTS)) {
+		for (size_t j = 0; j < ifo->vsio6_ent_nums_len; j++)
+			p += dhcp6_makevendoropts(p, ifp, ifo->vsio6_ent_nums[j]);
+	}
 
 	if (state->send->type != DHCP6_RELEASE &&
 	    state->send->type != DHCP6_DECLINE)

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -147,6 +147,7 @@ const struct option cf_options[] = {
 	{"embed",           required_argument, NULL, O_EMBED},
 	{"encap",           required_argument, NULL, O_ENCAP},
 	{"vendopt",         required_argument, NULL, O_VENDOPT},
+	{"vsio",         	required_argument, NULL, O_VENDOPT6},
 	{"vendclass",       required_argument, NULL, O_VENDCLASS},
 	{"authprotocol",    required_argument, NULL, O_AUTHPROTOCOL},
 	{"authtoken",       required_argument, NULL, O_AUTHTOKEN},
@@ -647,6 +648,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 	char *p = NULL, *bp, *fp, *np;
 	ssize_t s;
 	struct in_addr addr, addr2;
+	struct in6_addr in6addr;
 	in_addr_t *naddr;
 	struct rt *rt;
 	const struct dhcp_opt *d, *od;
@@ -654,6 +656,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 	struct dhcp_opt **dop, *ndop;
 	size_t *dop_len, dl, odl;
 	struct vivco *vivco;
+	struct vsio6 *vsio6;
 	struct group *grp;
 #ifdef AUTH
 	struct token *token;
@@ -2015,6 +2018,102 @@ err_sla:
 		vivco->len = dl;
 		vivco->data = (uint8_t *)np;
 		break;
+
+	case O_VENDOPT6:
+		ARG_REQUIRED;
+		fp = strwhite(arg);
+		if (fp)
+			*fp++ = '\0';
+		u = (uint32_t)strtou(arg, NULL, 0, 0, UINT32_MAX, &e);
+		if (e) {
+			logerrx("invalid code: %s", arg);
+			return -1;
+		}
+
+		fp = strskipwhite(fp);
+		p = strchr(fp, ',');
+		if (!p || !p[1]) {
+			logerrx("invalid vendor format: %s", arg);
+			return -1;
+		}
+
+		/* Strip and preserve the comma */
+		*p = '\0';
+		i = (int)strtoi(fp, NULL, 0, 1, 65535, &e);
+		*p = ',';
+		if (e) {
+			logerrx("vendor6 option should be between"
+			    " 1 and 65535 inclusive");
+			return -1;
+		}
+
+		fp = p + 1;
+
+		if (fp) {
+			if (inet_pton(AF_INET6, fp, &in6addr) == 1) {
+				s = sizeof(in6addr.s6_addr);
+				dl = (size_t)s;
+				if (dl + (sizeof(uint16_t) * 2) > UINT16_MAX) {
+					logerrx("vendor6 option is too big");
+					return -1;
+				}
+				np = malloc(dl);
+				if (np == NULL) {
+					logerr(__func__);
+					return -1;
+				}
+				memcpy(np, &in6addr.s6_addr, dl);
+			} else {
+				s = parse_string(NULL, 0, fp);
+				if(s == -1) {
+					logerr(__func__);
+					return -1;
+				}
+				dl = (size_t)s;
+				if (dl + (sizeof(uint16_t) * 2) > UINT16_MAX) {
+					logerrx("vendor6 option is too big");
+					return -1;
+				}
+				np = malloc(dl);
+				if (np == NULL) {
+					logerr(__func__);
+					return -1;
+				}
+				parse_string(np, dl, fp);
+			}
+		} else {
+			dl = 0;
+			np = NULL;
+		}
+
+		vsio6 = reallocarray(ifo->vsio6, ifo->vsio6_len + 1, sizeof(*ifo->vsio6));
+		if (vsio6 == NULL) {
+			logerr(__func__);
+			free(np);
+			return -1;
+		}
+		ifo->vsio6 = vsio6;
+		vsio6 = &ifo->vsio6[ifo->vsio6_len++];
+		vsio6->en = (uint32_t)u;
+		vsio6->opt = (size_t)i;
+		vsio6->len = dl;
+		vsio6->data = (uint8_t *)np;
+		
+		bool new_en = true;
+		for (size_t j = 0; j < ifo->vsio6_ent_nums_len; j++) {
+			if (ifo->vsio6_ent_nums[j] == (uint32_t)u) {
+				new_en = false;
+				break;
+			}
+		}
+
+		if (new_en) {
+			ifo->vsio6_ent_nums[ifo->vsio6_ent_nums_len] = (uint32_t)u;
+			ifo->vsio6_ent_nums_len++;
+		}
+
+		break;
+
 	case O_AUTHPROTOCOL:
 		ARG_REQUIRED;
 #ifdef AUTH
@@ -2798,6 +2897,7 @@ free_options(struct dhcpcd_ctx *ctx, struct if_options *ifo)
 #endif
 	struct dhcp_opt *opt;
 	struct vivco *vo;
+	struct vsio6 *vso6;
 #ifdef AUTH
 	struct token *token;
 #endif
@@ -2856,6 +2956,11 @@ free_options(struct dhcpcd_ctx *ctx, struct if_options *ifo)
 	    vo++, ifo->vivco_len--)
 		free(vo->data);
 	free(ifo->vivco);
+	for (vso6 = ifo->vsio6;
+	    ifo->vsio6_len > 0;
+	    vso6++, ifo->vsio6_len--)
+			free(vso6->data);
+	free(ifo->vsio6);
 	for (opt = ifo->vivso_override;
 	    ifo->vivso_override_len > 0;
 	    opt++, ifo->vivso_override_len--)

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -193,6 +193,7 @@
 #define O_FALLBACK_TIME		O_BASE + 55
 #define O_IPV4LL_TIME		O_BASE + 56
 #define O_VENDOPT6		O_BASE + 57
+#define O_VIVSO			O_BASE + 58
 
 extern const struct option cf_options[];
 
@@ -227,6 +228,13 @@ struct vivco {
 struct vsio6 {
 	uint32_t en;
 	size_t opt;
+	size_t len;
+	uint8_t *data;
+};
+
+struct vivso4 {
+	uint32_t en;
+	uint8_t opt;
 	size_t len;
 	uint8_t *data;
 };
@@ -305,6 +313,12 @@ struct if_options {
 	size_t vsio6_len;
 	uint32_t vsio6_ent_nums[ENTERPRISE_NUMS_MAX_LEN]; // Unique enterprise ID's will be saved here
 	size_t vsio6_ent_nums_len;
+	
+	struct vivso4 *vivso4;
+	size_t vivso4_len;
+	uint32_t vivso4_ent_nums[ENTERPRISE_NUMS_MAX_LEN];
+	size_t vivso4_ent_nums_len;
+
 
 	struct auth auth;
 };

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -61,6 +61,7 @@
 #define USERCLASS_MAX_LEN	255
 #define VENDOR_MAX_LEN		255
 #define	MUDURL_MAX_LEN		255
+#define ENTERPRISE_NUMS_MAX_LEN	255
 
 #define DHCPCD_ARP			(1ULL << 0)
 #define DHCPCD_RELEASE			(1ULL << 1)
@@ -191,6 +192,7 @@
 #define O_REQUEST_TIME		O_BASE + 54
 #define O_FALLBACK_TIME		O_BASE + 55
 #define O_IPV4LL_TIME		O_BASE + 56
+#define O_VENDOPT6		O_BASE + 57
 
 extern const struct option cf_options[];
 
@@ -218,6 +220,13 @@ struct if_ia {
 };
 
 struct vivco {
+	size_t len;
+	uint8_t *data;
+};
+
+struct vsio6 {
+	uint32_t en;
+	size_t opt;
 	size_t len;
 	uint8_t *data;
 };
@@ -292,6 +301,10 @@ struct if_options {
 	size_t vivco_len;
 	struct dhcp_opt *vivso_override;
 	size_t vivso_override_len;
+	struct vsio6 *vsio6;
+	size_t vsio6_len;
+	uint32_t vsio6_ent_nums[ENTERPRISE_NUMS_MAX_LEN]; // Unique enterprise ID's will be saved here
+	size_t vsio6_ent_nums_len;
 
 	struct auth auth;
 };


### PR DESCRIPTION
This is the same patch which was posted here:
https://github.com/NetworkConfiguration/dhcpcd/issues/74