### PR TITLE
Apply lastlease behavior to DHCPv6

### DIFF
--- a/hooks/dhcpcd-run-hooks.8.in
+++ b/hooks/dhcpcd-run-hooks.8.in
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 10, 2024
+.Dd October 11, 2024
 .Dt DHCPCD-RUN-HOOKS 8
 .Os
 .Sh NAME
@@ -114,7 +114,7 @@ dhcpcd has been configured with a static configuration which has not been
 obtained from a DHCP server.
 .It Dv 3RDPARTY
 dhcpcd is monitoring the interface for a 3rd party to give it an IP address.
-.It Dv TIMEOUT
+.It Dv TIMEOUT | TIMEOUT6
 dhcpcd failed to contact any DHCP servers but was able to use an old lease.
 .It Dv EXPIRE | EXPIRE6
 dhcpcd's lease or state expired and it failed to obtain a new one.

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -1760,6 +1760,8 @@ dhcp6_fail(struct interface *ifp, bool drop)
 		dhcp_unlink(ifp->ctx, state->leasefile);
 		dhcp6_addrequestedaddrs(ifp);
 		eloop_timeout_delete(ifp->ctx->eloop, NULL, ifp);
+	} else if (state->recv && ifp->options->options & DHCPCD_LASTLEASE) {
+		dhcp6_bind(ifp, NULL, NULL);
 	} else if (state->new) {
 		script_runreason(ifp, "TIMEOUT6");
 		// We need to keep the expire timeout alive

--- a/src/dhcpcd.conf.5.in
+++ b/src/dhcpcd.conf.5.in
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 24, 2024
+.Dd October 11, 2024
 .Dt DHCPCD.CONF 5
 .Os
 .Sh NAME
@@ -471,6 +471,17 @@ always fork on a RA.
 Enables IPv6 Router Advertisement solicitation.
 This is on by default, but is documented here in the case where it is disabled
 globally but needs to be enabled for one interface.
+.It Ic lastlease
+If
+.Nm dhcpcd
+cannot obtain a lease, then try to use the last lease acquired for the
+interface.
+.It Ic lastleaseextend
+Same as the above, but the lease will be retained even if it expires.
+.Nm dhcpcd
+will give it up if any other host tries to claim it for their own via ARP.
+This violates RFC 2131, section 3.7, which states the lease should be
+dropped once it has expired.
 .It Ic leasetime Ar seconds
 Request DHCP a lease time of
 .Ar seconds .


### PR DESCRIPTION
If no response is received to Confirm messages, instead of failing, go ahead and use the lease, as recommended by RFC 8415 18.2.3.