### PR TITLE
DHCP6: lastlease behavior after Confim non-response

### DIFF
--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -187,6 +187,7 @@ static const char * const dhcp6_statuses[] = {
 
 static void dhcp6_bind(struct interface *, const char *, const char *);
 static void dhcp6_failinform(void *);
+static void dhcp6_startrebind(void *arg);
 static void dhcp6_recvaddr(void *, unsigned short);
 static void dhcp6_startdecline(struct interface *);
 static void dhcp6_startrequest(struct interface *);
@@ -1760,8 +1761,12 @@ dhcp6_fail(struct interface *ifp, bool drop)
 		dhcp_unlink(ifp->ctx, state->leasefile);
 		dhcp6_addrequestedaddrs(ifp);
 		eloop_timeout_delete(ifp->ctx->eloop, NULL, ifp);
-	} else if (state->recv && ifp->options->options & DHCPCD_LASTLEASE) {
+	} else if ((state->state == DH6S_CONFIRM || state->state == DH6S_REBIND) &&
+	           ifp->options->options & DHCPCD_LASTLEASE) {
 		dhcp6_bind(ifp, NULL, NULL);
+		state->state = DH6S_REBIND;
+		dhcp6_startrebind(ifp);
+		return;
 	} else if (state->new) {
 		script_runreason(ifp, "TIMEOUT6");
 		// We need to keep the expire timeout alive


### PR DESCRIPTION
If lastlease is enabled, and dhcpcd is unable to confirm its prior lease, after timeout, don't continue to solicit. Confine lastlease behavior to only the CONFIRM state.

This cleans up some minor issues with the initial commit for DHCPv6 lastlease.