### PR TITLE
Allow limited RLIMIT_FSIZE when dumping lease

### DIFF
--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -1739,6 +1739,13 @@ dhcpcd_readdump2(void *arg, unsigned short events)
 	if (ctx->ctl_buf[ctx->ctl_buflen - 1] != '\0') /* unlikely */
 		ctx->ctl_buf[ctx->ctl_buflen - 1] = '\0';
 	script_dump(ctx->ctl_buf, ctx->ctl_buflen);
+#ifdef PRIVSEP
+	// Check for redirect, if so, if privsep we need to open up priveleges
+	if (IN_PRIVSEP(ctx) && !isatty(fileno(stdout)))
+	{
+		logdebugx("dumplease stdout has been redirected");
+	}
+#endif
 	fflush(stdout);
 	if (--ctx->ctl_extra != 0) {
 		putchar('\n');


### PR DESCRIPTION
When PRIVSEP, set rlimit to 5Kb when dumping lease (all other privileges are still dropped).

Without this, redirecting dumplease to anything but stdout results in SIGXFSZ due to EBIG error.

Resolves #386 