### PR TITLE
Exit the timesyncd hook if not on systemd and not executable (#398)

### DIFF
--- a/hooks/50-timesyncd.conf
+++ b/hooks/50-timesyncd.conf
@@ -1,3 +1,10 @@
+if [ ! -d /run/systemd/system ]; then
+	return
+fi
+if [ ! -x /lib/systemd/systemd-timesyncd ]; then
+	return
+fi
+
 : ${timesyncd_conf_d:=/run/systemd/timesyncd.conf.d}
 timesyncd_conf="${timesyncd_conf_d}/dhcpcd-$ifname.conf"
 timesyncd_tmp_d="$state_dir/timesyncd"


### PR DESCRIPTION
Exit the timesyncd hook immediately if not running on a systemd host AND timesyncd is not executable.