### PR TITLE
Fix using multiple enterprise IDs with vendclass (Option 124 DHCP / Option 16 DHCPv6) (#328)

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -1159,7 +1159,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 				p += sizeof(ul);
 				datalen = (uint8_t)(sizeof(uint8_t) + vivco->len);
 				memcpy(p, &datalen, sizeof(datalen));
-				p += sizeof(datalen); // OK do tu
+				p += sizeof(datalen);
 				datalenopt = (uint8_t)(vivco->len);
 				memcpy(p, &datalenopt, sizeof(datalenopt));
 				p += sizeof(datalenopt);

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -1155,11 +1155,11 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 				lp = rfc3396_zero(&rctx);
 				if (lp == NULL)
 					goto toobig;
-				if (rfc3396_write_byte(&rctx,
-					(uint8_t)vivco->len) == -1)
+				if (rfc3396_write_byte(&rctx, 
+				    (uint8_t)vivco->len) == -1)
 					goto toobig;
-				if (rfc3396_write(&rctx,
-					vivco->data, vivco->len) == -1)
+				if (rfc3396_write(&rctx, 
+				    vivco->data, vivco->len) == -1)
 					goto toobig;
 				*lp = (uint8_t)(*lp + vivco->len + 1);
 			}

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -1155,10 +1155,10 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 				lp = rfc3396_zero(&rctx);
 				if (lp == NULL)
 					goto toobig;
-				if (rfc3396_write_byte(&rctx, 
+				if (rfc3396_write_byte(&rctx,
 				    (uint8_t)vivco->len) == -1)
 					goto toobig;
-				if (rfc3396_write(&rctx, 
+				if (rfc3396_write(&rctx,
 				    vivco->data, vivco->len) == -1)
 					goto toobig;
 				*lp = (uint8_t)(*lp + vivco->len + 1);

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -276,6 +276,8 @@ dhcp6_makeuser(void *data, const struct interface *ifp)
 	return sizeof(o) + olen;
 }
 
+#ifndef SMALL
+/* DHCPv6 Option 16 (Vendor Class Option) */
 static size_t
 dhcp6_makevendor(void *data, const struct interface *ifp)
 {
@@ -345,7 +347,6 @@ dhcp6_makevendor(void *data, const struct interface *ifp)
 	return len;
 }
 
-#ifndef SMALL
 /* DHCPv6 Option 17 (Vendor-Specific Information Option) */
 static size_t
 dhcp6_makevendoropts(void *data, const struct interface *ifp)
@@ -878,10 +879,10 @@ dhcp6_makemessage(struct interface *ifp)
 
 	if (!has_option_mask(ifo->nomask6, D6_OPTION_USER_CLASS))
 		len += dhcp6_makeuser(NULL, ifp);
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
-		len += dhcp6_makevendor(NULL, ifp);
 
 #ifndef SMALL
+	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
+		len += dhcp6_makevendor(NULL, ifp);
 	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_OPTS))
 		len += dhcp6_makevendoropts(NULL, ifp);
 #endif
@@ -1202,10 +1203,10 @@ dhcp6_makemessage(struct interface *ifp)
 
 	if (!has_option_mask(ifo->nomask6, D6_OPTION_USER_CLASS))
 		p += dhcp6_makeuser(p, ifp);
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
-		p += dhcp6_makevendor(p, ifp);
 
 #ifndef SMALL
+	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
+		p += dhcp6_makevendor(p, ifp);
 	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_OPTS))
 		p += dhcp6_makevendoropts(p, ifp);
 #endif

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -2112,6 +2112,10 @@ err_sla:
 		break;
 	case O_VENDCLASS:
 		ARG_REQUIRED;
+#ifdef SMALL
+			logwarnx("%s: vendor options not compiled in", ifname);
+			return -1;
+#else
 		fp = strwhite(arg);
 		if (fp)
 			*fp++ = '\0';
@@ -2122,7 +2126,7 @@ err_sla:
 		}
 		for (vivco = ifo->vivco; vivco != vivco_endp; vivco++) {
 			if (vivco->en == (uint32_t)u) {
-				logerrx("only one vendor class option per enterprise number");
+				logerrx("vendor class option for enterprise number %u already defined", vivco->en);
 				return -1;
 			}
 		}
@@ -2161,6 +2165,7 @@ err_sla:
 		vivco->len = dl;
 		vivco->data = (uint8_t *)np;
 		break;
+#endif
 	case O_AUTHPROTOCOL:
 		ARG_REQUIRED;
 #ifdef AUTH
@@ -3001,12 +3006,12 @@ free_options(struct dhcpcd_ctx *ctx, struct if_options *ifo)
 	    opt++, ifo->dhcp6_override_len--)
 		free_dhcp_opt_embenc(opt);
 	free(ifo->dhcp6_override);
+#ifndef SMALL
 	for (vo = ifo->vivco;
 	    ifo->vivco_len > 0;
 	    vo++, ifo->vivco_len--)
 		free(vo->data);
 	free(ifo->vivco);
-#ifndef SMALL
 	for (vsio = ifo->vsio;
 	    ifo->vsio_len > 0;
 	    vsio++, ifo->vsio_len--)

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -656,6 +656,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 	struct dhcp_opt **dop, *ndop;
 	size_t *dop_len, dl, odl;
 	struct vivco *vivco;
+	const struct vivco *vivco_endp = ifo->vivco + ifo->vivco_len;
 	struct group *grp;
 #ifdef AUTH
 	struct token *token;
@@ -2119,6 +2120,12 @@ err_sla:
 			logerrx("invalid code: %s", arg);
 			return -1;
 		}
+		for (vivco = ifo->vivco; vivco != vivco_endp; vivco++) {
+			if (vivco->en == (uint32_t)u) {
+				logerrx("only one vendor class option per enterprise number");
+				return -1;
+			}
+		}
 		fp = strskipwhite(fp);
 		if (fp) {
 			s = parse_string(NULL, 0, fp);
@@ -2149,8 +2156,8 @@ err_sla:
 			return -1;
 		}
 		ifo->vivco = vivco;
-		ifo->vivco_en = (uint32_t)u;
 		vivco = &ifo->vivco[ifo->vivco_len++];
+		vivco->en = (uint32_t)u;
 		vivco->len = dl;
 		vivco->data = (uint8_t *)np;
 		break;

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -61,7 +61,6 @@
 #define USERCLASS_MAX_LEN	255
 #define VENDOR_MAX_LEN		255
 #define	MUDURL_MAX_LEN		255
-#define ENTERPRISE_NUMS_MAX_LEN	255
 
 #define DHCPCD_ARP			(1ULL << 0)
 #define DHCPCD_RELEASE			(1ULL << 1)
@@ -221,6 +220,7 @@ struct if_ia {
 };
 
 struct vivco {
+	uint32_t en;
 	size_t len;
 	uint8_t *data;
 };
@@ -303,7 +303,6 @@ struct if_options {
 	size_t nd_override_len;
 	struct dhcp_opt *dhcp6_override;
 	size_t dhcp6_override_len;
-	uint32_t vivco_en;
 	struct vivco *vivco;
 	size_t vivco_len;
 	struct dhcp_opt *vivso_override;

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -219,13 +219,12 @@ struct if_ia {
 #endif
 };
 
+#ifndef SMALL
 struct vivco {
 	uint32_t en;
 	size_t len;
 	uint8_t *data;
 };
-
-#ifndef SMALL
 struct vsio_so {
 	uint16_t opt;
 	uint16_t len;
@@ -303,12 +302,12 @@ struct if_options {
 	size_t nd_override_len;
 	struct dhcp_opt *dhcp6_override;
 	size_t dhcp6_override_len;
-	struct vivco *vivco;
-	size_t vivco_len;
 	struct dhcp_opt *vivso_override;
 	size_t vivso_override_len;
 
 #ifndef SMALL
+	size_t vivco_len;
+	struct vivco *vivco;
 	size_t vsio_len;
 	struct vsio *vsio;
 	size_t vsio6_len;


### PR DESCRIPTION
As it's outlined in #328, using multiple enterprise IDs with vendclass overwrites all previous values.
This fixes the malformation of the DHCPv4 packet and adds support for multiple different enterprise ID vendclass options.