### PR TITLE
Update route if acquired time changes

### DIFF
--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -754,7 +754,7 @@ if_copyrt(struct dhcpcd_ctx *ctx, struct rt *rt, struct nlmsghdr *nlm)
 		}
 		case RTA_EXPIRES:
 		{
-			rt->rt_expires = *(uint32_t *)RTA_DATA(rta);
+			rt->rt_lifetime = *(uint32_t *)RTA_DATA(rta);
 			break;
 		}
 		}
@@ -1740,9 +1740,8 @@ if_route(unsigned char cmd, const struct rt *rt)
 	if (!sa_is_loopback(&rt->rt_gateway))
 		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_OIF, rt->rt_ifp->index);
 
-	/* add route lifetime */
-	if (rt->rt_expires != 0)
-		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_EXPIRES, rt->rt_expires);
+	if (rt->rt_lifetime != 0)
+		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_EXPIRES, rt->rt_lifetime);
 	if (rt->rt_metric != 0)
 		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_PRIORITY,
 		    rt->rt_metric);

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -1743,7 +1743,6 @@ if_route(unsigned char cmd, const struct rt *rt)
 	/* add route lifetime */
 	if (rt->rt_expires != 0)
 		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_EXPIRES, rt->rt_expires);
-
 	if (rt->rt_metric != 0)
 		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_PRIORITY,
 		    rt->rt_metric);

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2301,10 +2301,10 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 #ifdef HAVE_ROUTE_PREF
 			rt->rt_pref = ipv6nd_rtpref(rinfo->flags);
 #endif
+#ifdef HAVE_ROUTE_LIFETIME
 			rt->rt_expires = lifetime_left(rinfo->lifetime,
 			    &rinfo->acquired, &now);
-			rt->rt_updated = rinfo->acquired;
-
+#endif
 			rt_proto_add(routes, rt);
 		}
 
@@ -2318,10 +2318,11 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 #ifdef HAVE_ROUTE_PREF
 				rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
+#ifdef HAVE_ROUTE_LIFETIME
 				rt->rt_expires =
 				    lifetime_left(addr->prefix_vltime,
 				    &addr->acquired, &now);
-				rt->rt_updated = addr->acquired;
+#endif
 
 				rt_proto_add(routes, rt);
 			}
@@ -2354,9 +2355,10 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 #ifdef HAVE_ROUTE_PREF
 		rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
+#ifdef HAVE_ROUTE_LIFETIME
 		rt->rt_expires = lifetime_left(rap->lifetime,
 		    &rap->acquired, &now);
-		rt->rt_updated = rap->acquired;
+#endif
 
 		rt_proto_add(routes, rt);
 	}

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2329,6 +2329,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 			rt->rt_pref = ipv6nd_rtpref(rinfo->flags);
 #endif
 			rt->rt_expires = lifetime_left(rinfo->lifetime, &rinfo->acquired, &now);
+			rt->rt_updated = rinfo->acquired;
 
 			rt_proto_add(routes, rt);
 		}
@@ -2344,6 +2345,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 				rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 				rt->rt_expires = lifetime_left(addr->prefix_vltime, &addr->acquired, &now);
+				rt->rt_updated = addr->acquired;
 
 				rt_proto_add(routes, rt);
 			}
@@ -2377,6 +2379,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 		rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 		rt->rt_expires = lifetime_left(rap->lifetime, &rap->acquired, &now);
+		rt->rt_updated = rap->acquired;
 
 		rt_proto_add(routes, rt);
 	}

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2302,7 +2302,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 			rt->rt_pref = ipv6nd_rtpref(rinfo->flags);
 #endif
 #ifdef HAVE_ROUTE_LIFETIME
-			rt->rt_expires = lifetime_left(rinfo->lifetime,
+			rt->rt_lifetime = lifetime_left(rinfo->lifetime,
 			    &rinfo->acquired, &now);
 #endif
 			rt_proto_add(routes, rt);
@@ -2319,7 +2319,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 				rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 #ifdef HAVE_ROUTE_LIFETIME
-				rt->rt_expires =
+				rt->rt_lifetime =
 				    lifetime_left(addr->prefix_vltime,
 				    &addr->acquired, &now);
 #endif
@@ -2356,7 +2356,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 		rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 #ifdef HAVE_ROUTE_LIFETIME
-		rt->rt_expires = lifetime_left(rap->lifetime,
+		rt->rt_lifetime = lifetime_left(rap->lifetime,
 		    &rap->acquired, &now);
 #endif
 

--- a/src/route.c
+++ b/src/route.c
@@ -556,7 +556,7 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 	    sa_cmp(&ort->rt_gateway, &nrt->rt_gateway) == 0)
 	{
 		/* If it has not been renewed by RA, and MTU is unchanged, skip */
-		if (ort->rt_updated == nrt->rt_updated &&
+		if (ort->rt_updated.tv_sec == nrt->rt_updated.tv_sec &&
 			ort->rt_mtu == nrt->rt_mtu)
 			return true;
 		change = true;
@@ -681,7 +681,7 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 		    (rt->rt_ifa.sa_family != AF_UNSPEC &&
 		    sa_cmp(&or->rt_ifa, &rt->rt_ifa) != 0) ||
 		    or->rt_mtu != rt->rt_mtu ||
-			or->rt_updated != rt->rt_updated)
+			or->rt_updated.tv_sec != rt->rt_updated.tv_sec)
 		{
 			if (!rt_add(kroutes, rt, or))
 				return false;

--- a/src/route.c
+++ b/src/route.c
@@ -555,7 +555,9 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 	    rt_cmp_netmask(ort, nrt) == 0 &&
 	    sa_cmp(&ort->rt_gateway, &nrt->rt_gateway) == 0)
 	{
-		if (ort->rt_mtu == nrt->rt_mtu)
+		/* If it has not been renewed by RA, and MTU is unchanged, skip */
+		if (ort->rt_updated == nrt->rt_updated &&
+			ort->rt_mtu == nrt->rt_mtu)
 			return true;
 		change = true;
 	}
@@ -678,7 +680,8 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 		    !rt_cmp(rt, or) ||
 		    (rt->rt_ifa.sa_family != AF_UNSPEC &&
 		    sa_cmp(&or->rt_ifa, &rt->rt_ifa) != 0) ||
-		    or->rt_mtu != rt->rt_mtu)
+		    or->rt_mtu != rt->rt_mtu ||
+			or->rt_updated != rt->rt_updated)
 		{
 			if (!rt_add(kroutes, rt, or))
 				return false;

--- a/src/route.c
+++ b/src/route.c
@@ -513,7 +513,7 @@ rt_changed(struct rt *nrt, struct rt *ort)
 #ifdef HAVE_ROUTE_LIFETIME
 	/* If the expired target time is different, we have updated our expired time
 	 * from a new RA and should pass that value on to the system */
-	if (abs(nrt->rt_expires - nrt->rt_expires) > 30)
+	if (abs((int64_t)nrt->rt_expires - (int64_t)ort->rt_expires) > 30)
 		return true;
 #endif
 
@@ -558,7 +558,7 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 #endif
 		    sa_cmp(&ort->rt_gateway, &nrt->rt_gateway) == 0)))
 		{
-			change = rt_changed();
+			change = rt_changed(nrt, ort);
 			if (!change)
 				return true;
 			kroute = true;
@@ -573,7 +573,7 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 	    rt_cmp_netmask(ort, nrt) == 0 &&
 	    sa_cmp(&ort->rt_gateway, &nrt->rt_gateway) == 0)
 	{
-		change = rt_changed();
+		change = rt_changed(nrt, ort);
 		if (!change)
 			return true;
 	}
@@ -696,7 +696,7 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 		    !rt_cmp(rt, or) ||
 		    (rt->rt_ifa.sa_family != AF_UNSPEC &&
 		    sa_cmp(&or->rt_ifa, &rt->rt_ifa) != 0) ||
-		    rt_changed())
+		    rt_changed(rt, or))
 		{
 			if (!rt_add(kroutes, rt, or))
 				return false;

--- a/src/route.c
+++ b/src/route.c
@@ -543,8 +543,8 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 		    sa_cmp(&ort->rt_gateway, &nrt->rt_gateway) == 0)))
 		{
 			/* If expiry has not been renewed by RA, and MTU is unchanged, skip */
-			if (ort->rt_mtu != nrt->rt_mtu) ||
-				(ort->rt_updated.tv_sec != nrt->rt_updated.tv_sec)
+			if (ort->rt_mtu != nrt->rt_mtu ||
+				ort->rt_updated.tv_sec != nrt->rt_updated.tv_sec)
 				change = true;
 			if (!change)
 				return true;
@@ -561,8 +561,8 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 	    sa_cmp(&ort->rt_gateway, &nrt->rt_gateway) == 0)
 	{
 		/* If expiry has not been renewed by RA, and MTU is unchanged, skip */
-		if (ort->rt_mtu != nrt->rt_mtu) ||
-			(ort->rt_updated.tv_sec != nrt->rt_updated.tv_sec)
+		if (ort->rt_mtu != nrt->rt_mtu ||
+			ort->rt_updated.tv_sec != nrt->rt_updated.tv_sec)
 			change = true;
 		if (!change)
 			return true;

--- a/src/route.c
+++ b/src/route.c
@@ -566,7 +566,6 @@ rt_add(rb_tree_t *kroutes, struct rt *nrt, struct rt *ort)
 			change = true;
 		if (!change)
 			return true;
-		change = true;
 	}
 
 #ifdef RTF_CLONING

--- a/src/route.h
+++ b/src/route.h
@@ -126,7 +126,7 @@ struct rt {
 	size_t			rt_order;
 	rb_node_t		rt_tree;
 #ifdef HAVE_ROUTE_LIFETIME
-	uint32_t		rt_expires;	/* current lifetime of route */
+	uint32_t		rt_lifetime;	/* current lifetime of route */
 #endif
 };
 

--- a/src/route.h
+++ b/src/route.h
@@ -59,6 +59,11 @@
 #  define HAVE_ROUTE_METRIC 1
 # endif
 #endif
+#ifndef HAVE_ROUTE_LIFETIME
+# if defined(__linux__)
+#  define HAVE_ROUTE_LIFETIME 1
+# endif
+#endif
 
 #ifdef __linux__
 # include <linux/version.h> /* RTA_PREF is only an enum.... */
@@ -120,8 +125,9 @@ struct rt {
 #define	RTDF_GATELINK		0x40		/* Gateway is on link */
 	size_t			rt_order;
 	rb_node_t		rt_tree;
+#ifdef HAVE_ROUTE_LIFETIME
 	uint32_t		rt_expires;	/* current lifetime of route */
-	struct timespec	rt_updated; /* time route was last updated */
+#endif
 };
 
 extern const rb_tree_ops_t rt_compare_list_ops;

--- a/src/route.h
+++ b/src/route.h
@@ -121,6 +121,7 @@ struct rt {
 	size_t			rt_order;
 	rb_node_t		rt_tree;
 	uint32_t		rt_expires;	/* current lifetime of route */
+	struct timespec	rt_updated; /* time route was last updated */
 };
 
 extern const rb_tree_ops_t rt_compare_list_ops;

--- a/src/route.h
+++ b/src/route.h
@@ -61,7 +61,7 @@
 #endif
 #ifndef HAVE_ROUTE_LIFETIME
 # if defined(__linux__)
-#  define HAVE_ROUTE_LIFETIME 1
+#  define HAVE_ROUTE_LIFETIME 1 /* For IPv6 routes only */
 # endif
 #endif
 
@@ -127,6 +127,7 @@ struct rt {
 	rb_node_t		rt_tree;
 #ifdef HAVE_ROUTE_LIFETIME
 	uint32_t		rt_lifetime;	/* current lifetime of route */
+#define	RTLIFETIME_DEV_MAX	2 		/* max deviation for cmp */
 #endif
 };
 


### PR DESCRIPTION
If a route gets an update (say from an RA), consider it changed so new expiry gets pushed out to system.

Resolves #428 