### PR TITLE
Uncomment 'hostname' in dhcpcd.conf

### DIFF
--- a/src/dhcpcd.conf
+++ b/src/dhcpcd.conf
@@ -5,7 +5,7 @@
 #controlgroup wheel
 
 # Inform the DHCP server of our hostname for DDNS.
-#hostname
+hostname
 
 # Use the hardware address of the interface for the Client ID.
 #clientid


### PR DESCRIPTION
dhcpcd routinely fails to obtain an IP with a timeout if the DHCP server doesn't receive the "hostname" option. Let's uncomment it.