### PR TITLE
Restore logic on when to open an address specific socket

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -2384,8 +2384,8 @@ dhcp_bound(struct interface *ifp, uint8_t old_state)
 	if (ctx->options & DHCPCD_MANAGER ||
 	    ifp->options->options & DHCPCD_STATIC ||
 	    (state->old != NULL &&
-		state->old->yiaddr == state->new->yiaddr) ||
-	    (old_state & STATE_ADDED && !(old_state & STATE_FAKE)))
+	     state->old->yiaddr == state->new->yiaddr &&
+	     old_state & STATE_ADDED && !(old_state & STATE_FAKE)))
 		return;
 
 	dhcp_closeinet(ifp);


### PR DESCRIPTION
850f93b changed the logic while moving things around. Restore the original logic so we open a socket even if the address is the same, so long as it's the first time.

Fixes: #501
