### PR TITLE
[Fix] DHCP Failure on WAN Interface Rename (Fixes #504)

### DIFF
--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -1137,7 +1137,7 @@ link_netlink(struct dhcpcd_ctx *ctx, void *arg, struct nlmsghdr *nlm)
 
 	/* Handle interface being renamed */
 	if (strcmp(ifp->name, ifn) != 0) {
-		dhcpcd_handleinterface(ctx, -1, ifn);
+		dhcpcd_handleinterface(ctx, -1, ifp->name);
 		dhcpcd_handleinterface(ctx, 1, ifn);
 		return 0;
 	}


### PR DESCRIPTION
As discussed in #504 , this fixes a DHCP issue when the WAN interface rename, left `/etc/resolv.conf` empty. The change updates `if-linux.c` to stop the old interface (`ifp->name`) and start the new one (`ifn`)