### PR TITLE
privsep: enforce message boundaries with MSG_EOR on our messages

### DIFF
--- a/src/privsep.c
+++ b/src/privsep.c
@@ -934,7 +934,9 @@ ps_sendpsmmsg(struct dhcpcd_ctx *ctx, int fd,
 	} else
 		iovlen = 1;
 
-	len = writev(fd, iov, iovlen);
+	len = sendmsg(fd,
+	    &(struct msghdr){ .msg_iov = iov, .msg_iovlen = iovlen }, MSG_EOR);
+
 	if (len == -1) {
 		if (ctx->options & DHCPCD_FORKED &&
 		    !(ctx->options & DHCPCD_PRIVSEPROOT))
@@ -1063,7 +1065,9 @@ ps_sendcmdmsg(int fd, uint16_t cmd, const struct msghdr *msg)
 	    psm.ps_namelen + psm.ps_controllen + psm.ps_datalen + cmsg_padlen;
 	if (psm.ps_datalen != 0)
 		memcpy(p, msg->msg_iov[0].iov_base, psm.ps_datalen);
-	return writev(fd, iov, __arraycount(iov));
+	return sendmsg(fd,
+	    &(struct msghdr){ .msg_iov = iov, .msg_iovlen = __arraycount(iov) },
+	    MSG_EOR);
 
 nobufs:
 	errno = ENOBUFS;


### PR DESCRIPTION
The nature of the SOCK_SEQPACKET, that privsep modules uses, is stream. See:

https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html#tag_16_10_06

To guarantee that a reader will never read two messages in one read operation, the writer shall put end of record markers.

The problem exposed itself in FreeBSD 15.0 that started to follow the specification better than before.

Other SOCK_SEQPACKET usage considerations: a) as long as our reader provides a receive buffer that would fit the largest message our writer would ever send, we are good with regards to not a reading a partial message b) as long as our writer always write full messages with one write, we don't need use of MSG_WAITALL in reader.

Fixes #530