### PR TITLE
Enable ntp if autodetect ntpd or timesyncd

### DIFF
--- a/configure
+++ b/configure
@@ -40,7 +40,6 @@ SANITIZE=no
 STATUSARG=
 OPENSSL=
 NTPD=
-CHRONYD=
 TIMESYNCD=
 
 DHCPCD_DEFS=dhcpcd-definitions.conf
@@ -1701,13 +1700,14 @@ if [ -z "$STATUSARG" ]; then
 fi
 echo "STATUSARG=	$STATUSARG" >>config.mk
 
+if [ "$NTPD" = "yes" ] && [ "$TIMESYNCD" = "yes" ]; then
+	echo "Warning: --enable-ntpd and --enable-timesyncd are both set" >&2
+	exit 1
+fi
+
 HOOKS=
 if ! $HOOKSET; then
     if ! [ "$NTP" = "no" ]; then
-	    if [ "$NTPD" = "yes" ] && [ "$TIMESYNCD" = "yes" ]; then
-			echo "Warning: --enable-ntpd and --enable-timesyncd are both set" >&2
-			exit 1
-		fi
 		printf "Checking for ntpd ... "
 		NTPD_PATH=$(_which ntpd)
 		if [ -n "$NTPD_PATH" ]; then
@@ -1746,6 +1746,11 @@ if ! $HOOKSET; then
 			echo "$TIMESYNCD_PATH (Selecting 50-timesyncd.conf)"
 		else
 			echo "not found"
+		fi
+
+		 # Warn if both ntpd/chronyd and timesyncd are detected
+		if [ "$NTPD" = "yes" ] && [ -n "$TIMESYNCD_PATH" ]; then
+			echo "Both ntpd/chronyd and timesyncd detected; NTP will default to ntpd"
 		fi
 
 		# Choose hook based on enabled time service

--- a/configure
+++ b/configure
@@ -1703,22 +1703,9 @@ if [ -z "$STATUSARG" ]; then
 fi
 echo "STATUSARG=	$STATUSARG" >>config.mk
 
-if [ "$NTPD" = "yes" ] && [ "$TIMESYNCD" = "yes" ]; then
-	echo "Warning: --enable-ntpd and --enable-timesyncd are both set" >&2
-	exit 1
-fi
-
 HOOKS=
 if ! $HOOKSET; then
     if ! [ "$NTP" = "no" ]; then
-		# Explicit service selection should disable autodetect of the other service.
-		if [ "$TIMESYNCD" = "yes" ] && [ -z "$NTPD" ]; then
-			NTPD=no
-		fi
-		if [ "$NTPD" = "yes" ] && [ -z "$TIMESYNCD" ]; then
-			TIMESYNCD=no
-		fi
-
 	    printf "Checking for ntpd ... "
 	    if [ -z "$NTPD" ]; then
 		    # if not explicitly set enable/disable, try to autodetect
@@ -1747,6 +1734,8 @@ if ! $HOOKSET; then
 			fi
 		elif [ "$NTPD" = "no" ]; then
 			echo "skipped"
+		else
+			echo "selected via --enable-ntpd (Selecting 50-ntp.conf)"
 		fi
 
 		printf "Checking for timesyncd ... "
@@ -1767,17 +1756,15 @@ if ! $HOOKSET; then
 			fi
 		elif [ "$TIMESYNCD" = "no" ]; then
 			echo "skipped"
-		fi
-
-		# Warn if both ntpd/chronyd and timesyncd are detected
-		if [ "$NTPD" = "yes" ] && [ -n "$TIMESYNCD_PATH" ]; then
-			echo "Both ntpd/chronyd and timesyncd detected; NTP will default to ntpd"
+		else
+			echo "selected via --enable-timesyncd (Selecting 50-timesyncd.conf)"
 		fi
 
 		# Choose hook based on enabled time service
 		if [ "$NTPD" = "yes" ]; then
 			HOOKS="$HOOKS${HOOKS:+ }50-ntp.conf"
-		elif [ "$TIMESYNCD" = "yes" ]; then
+		fi
+		if [ "$TIMESYNCD" = "yes" ]; then
 			HOOKS="$HOOKS${HOOKS:+ }50-timesyncd.conf"
 		fi
 	fi
@@ -1845,14 +1832,7 @@ if [ -z "$NTP" ]; then
 fi
 if [ "$NTP" = "yes" ]; then 
 	# --enable-ntp or ntp/timesyncd service was autodetected
-	printf "Enabling NTP support for ... "
-	if [ "$NTPD" = "yes" ]; then
-		echo "ntpd"
-	elif [ "$TIMESYNCD" = "yes" ]; then
-		echo "timesyncd"
-	else
-		echo "user defined time service via HOOKSCRIPTS"
-	fi
+	echo "Enabling NTP support"
 	echo "UNCOMMENT_NTP=	yes" >>$CONFIG_MK
 else
 	# --disable-ntp

--- a/configure
+++ b/configure
@@ -1829,12 +1829,6 @@ if ! $HOOKSET; then
 	fi
 fi
 
-if [ -z "$NTP" ]; then
-	if [ "$NTPD" = "yes" ] || [ "$TIMESYNCD" = "yes" ]; then
-		NTP=yes
-	fi
-fi
-
 echo >>$CONFIG_H
 echo "#endif /*CONFIG_H*/">>$CONFIG_H
 

--- a/configure
+++ b/configure
@@ -1711,6 +1711,14 @@ fi
 HOOKS=
 if ! $HOOKSET; then
     if ! [ "$NTP" = "no" ]; then
+		# Explicit service selection should disable autodetect of the other service.
+		if [ "$TIMESYNCD" = "yes" ] && [ -z "$NTPD" ]; then
+			NTPD=no
+		fi
+		if [ "$NTPD" = "yes" ] && [ -z "$TIMESYNCD" ]; then
+			TIMESYNCD=no
+		fi
+
 	    printf "Checking for ntpd ... "
 	    if [ -z "$NTPD" ]; then
 		    # if not explicitly set enable/disable, try to autodetect

--- a/configure
+++ b/configure
@@ -39,6 +39,9 @@ SMALL=
 SANITIZE=no
 STATUSARG=
 OPENSSL=
+NTPD=
+CHRONYD=
+TIMESYNCD=
 
 DHCPCD_DEFS=dhcpcd-definitions.conf
 
@@ -77,6 +80,8 @@ for x do
 	--enable-seccomp) SECCOMP=yes;;
 	--disable-ntp) NTP=no;;
 	--enable-ntp) NTP=yes;;
+	--enable-ntpd) NTPD=yes; NTP=yes;;
+	--enable-timesyncd) TIMESYNCD=yes; NTP=yes;;
 	--privsepuser) PRIVSEP_USER=$var;;
 	--prefix) PREFIX=$var;prefix=$var;; # prefix is set for autotools compat
 	--sysconfdir) SYSCONFDIR=$var;;
@@ -1698,41 +1703,57 @@ echo "STATUSARG=	$STATUSARG" >>config.mk
 
 HOOKS=
 if ! $HOOKSET; then
-	printf "Checking for ntpd ... "
-	NTPD=$(_which ntpd)
-	if [ -n "$NTPD" ]; then
-		echo "$NTPD (50-ntp.conf)"
-	else
-		echo "not found"
-	fi
-	printf "Checking for chronyd ... "
-	CHRONYD=$(_which chronyd)
-	if [ -n "$CHRONYD" ]; then
-		echo "$CHRONYD (50-ntp.conf)"
-	else
-		echo "not found"
-	fi
-	if [ -n "$NTPD" ] || [ -n "$CHRONYD" ]; then
-		HOOKS="$HOOKS${HOOKS:+ }50-ntp.conf"
-	fi
-	# Warn if both are detected
-	if [ -n "$NTPD" ] && [ -n "$CHRONYD" ]; then
-		echo "NTP will default to $NTPD"
-	fi
-
-	printf "Checking for timesyncd ... "
-	TIMESYNCD=
-	for x in /usr/lib/systemd/systemd-timesyncd; do
-		if [ -x "$x" ]; then
-			TIMESYNCD=$x
-			break
+    if ! [ "$NTP" = "no" ]; then
+	    if [ "$NTPD" = "yes" ] && [ "$TIMESYNCD" = "yes" ]; then
+			echo "Warning: --enable-ntpd and --enable-timesyncd are both set" >&2
+			exit 1
 		fi
-	done
-	if [ -n "$TIMESYNCD" ]; then
-		echo "$TIMESYNCD"
-		HOOKS="$HOOKS${HOOKS:+ }50-timesyncd.conf"
-	else
-		echo "not found"
+		printf "Checking for ntpd ... "
+		NTPD_PATH=$(_which ntpd)
+		if [ -n "$NTPD_PATH" ]; then
+			NTPD=yes
+			NTP=yes
+			echo "$NTPD_PATH (Selecting 50-ntp.conf)"
+		else
+			echo "not found"
+		fi
+		printf "Checking for chronyd ... "
+		CHRONYD_PATH=$(_which chronyd)
+		if [ -n "$CHRONYD_PATH" ]; then
+			NTPD=yes
+			NTP=yes
+			echo "$CHRONYD_PATH (Selecting 50-ntp.conf)"
+		else
+			echo "not found"
+		fi
+		
+		# Warn if both are detected
+		if [ -n "$NTPD_PATH" ] && [ -n "$CHRONYD_PATH" ]; then
+			echo "NTP will default to $NTPD_PATH"
+		fi
+
+		printf "Checking for timesyncd ... "
+		TIMESYNCD_PATH=
+		for x in /usr/lib/systemd/systemd-timesyncd; do
+			if [ -x "$x" ]; then
+				TIMESYNCD=yes
+				TIMESYNCD_PATH=$x
+				NTP=yes
+				break
+			fi
+		done
+		if [ "$TIMESYNCD" = "yes" ]; then
+			echo "$TIMESYNCD_PATH (Selecting 50-timesyncd.conf)"
+		else
+			echo "not found"
+		fi
+
+		# Choose hook based on enabled time service
+		if [ "$NTPD" = "yes" ]; then
+			HOOKS="$HOOKS${HOOKS:+ }50-ntp.conf"
+		elif [ "$TIMESYNCD" = "yes" ]; then
+			HOOKS="$HOOKS${HOOKS:+ }50-timesyncd.conf"
+		fi
 	fi
 
 	printf "Checking for ypbind ... "
@@ -1790,9 +1811,24 @@ if ! $HOOKSET; then
 		fi
 	fi
 fi
-if [ "$NTP" = yes ]; then
-	# --enable-ntp
+
+if [ -z "$NTP" ]; then
+	if [ "$NTPD" = "yes" ] || [ "$TIMESYNCD" = "yes" ]; then
+		NTP=yes
+	fi
+fi
+if [ "$NTP" = "yes" ]; then 
+	# --enable-ntp or ntp/timesyncd service was autodetected
+	printf "Enabling NTP support for ... "
+	if [ "$NTPD" = "yes" ]; then
+		echo "ntpd"
+	elif [ "$TIMESYNCD" = "yes" ]; then
+		echo "timesyncd"
+	fi
 	echo "UNCOMMENT_NTP=	yes" >>$CONFIG_MK
+else
+	# --disable-ntp
+	echo "NTP support is disabled"
 fi
 
 echo >>$CONFIG_H

--- a/configure
+++ b/configure
@@ -1842,6 +1842,8 @@ if [ "$NTP" = "yes" ]; then
 		echo "ntpd"
 	elif [ "$TIMESYNCD" = "yes" ]; then
 		echo "timesyncd"
+	else
+		echo "user defined time service via HOOKSCRIPTS"
 	fi
 	echo "UNCOMMENT_NTP=	yes" >>$CONFIG_MK
 else

--- a/configure
+++ b/configure
@@ -1741,7 +1741,8 @@ if ! $HOOKSET; then
 		printf "Checking for timesyncd ... "
 		if [ -z "$TIMESYNCD" ]; then
 			TIMESYNCD_PATH=
-			for x in /usr/lib/systemd/systemd-timesyncd; do
+			for x in /lib/systemd/systemd-timesyncd \
+                /usr/lib/systemd/systemd-timesyncd; do
 				if [ -x "$x" ]; then
 					TIMESYNCD=yes
 					TIMESYNCD_PATH=$x

--- a/configure
+++ b/configure
@@ -40,7 +40,6 @@ SANITIZE=no
 STATUSARG=
 OPENSSL=
 NTPD=
-CHRONYD=
 TIMESYNCD=
 
 DHCPCD_DEFS=dhcpcd-definitions.conf
@@ -1709,7 +1708,6 @@ if ! $HOOKSET; then
 	    printf "Checking for ntpd ... "
 	    if [ -z "$NTPD" ]; then
 		    # if not explicitly set enable/disable, try to autodetect
-			
 			NTPD_PATH=$(_which ntpd)
 			if [ -n "$NTPD_PATH" ]; then
 				NTPD=yes
@@ -1835,9 +1833,12 @@ if [ "$NTP" = "yes" ]; then
 	# --enable-ntp or ntp/timesyncd service was autodetected
 	echo "Enabling NTP support"
 	echo "UNCOMMENT_NTP=	yes" >>$CONFIG_MK
-else
+elif [ "$NTP" = "no" ]; then
 	# --disable-ntp
 	echo "NTP support is disabled"
+else
+	# No NTP daemon detected
+	echo "NTP support not enabled (no daemon detected)"
 fi
 
 echo >>$CONFIG_H

--- a/configure
+++ b/configure
@@ -558,6 +558,11 @@ if [ -z "$INET6" ] || [ "$INET6" = yes ]; then
 		echo "DHCPCD_SRCS+=	dhcp6.c" >>$CONFIG_MK
 	fi
 fi
+if [ "$NTP" = "yes" ]; then
+	# NTP enabled: --enable-ntp, or implied by --enable-ntpd / --enable-timesyncd
+	echo "Enabling NTP support"
+	echo "UNCOMMENT_NTP=	yes" >>$CONFIG_MK
+fi
 if [ -z "$AUTH" ] || [ "$AUTH" = yes ]; then
 	echo "Enabling Authentication"
 	echo "CPPFLAGS+=	-DAUTH" >>$CONFIG_MK
@@ -1704,7 +1709,7 @@ echo "STATUSARG=	$STATUSARG" >>config.mk
 
 HOOKS=
 if ! $HOOKSET; then
-    if ! [ "$NTP" = "no" ]; then
+    if [ "$NTP" = "yes" ]; then
 	    printf "Checking for ntpd ... "
 	    if [ -z "$NTPD" ]; then
 		    # if not explicitly set enable/disable, try to autodetect
@@ -1828,17 +1833,6 @@ if [ -z "$NTP" ]; then
 	if [ "$NTPD" = "yes" ] || [ "$TIMESYNCD" = "yes" ]; then
 		NTP=yes
 	fi
-fi
-if [ "$NTP" = "yes" ]; then 
-	# --enable-ntp or ntp/timesyncd service was autodetected
-	echo "Enabling NTP support"
-	echo "UNCOMMENT_NTP=	yes" >>$CONFIG_MK
-elif [ "$NTP" = "no" ]; then
-	# --disable-ntp
-	echo "NTP support is disabled"
-else
-	# No NTP daemon detected
-	echo "NTP support not enabled (no daemon detected)"
 fi
 
 echo >>$CONFIG_H

--- a/configure
+++ b/configure
@@ -40,6 +40,7 @@ SANITIZE=no
 STATUSARG=
 OPENSSL=
 NTPD=
+CHRONYD=
 TIMESYNCD=
 
 DHCPCD_DEFS=dhcpcd-definitions.conf
@@ -79,7 +80,9 @@ for x do
 	--enable-seccomp) SECCOMP=yes;;
 	--disable-ntp) NTP=no;;
 	--enable-ntp) NTP=yes;;
+	--disable-ntpd) NTPD=no;;
 	--enable-ntpd) NTPD=yes; NTP=yes;;
+	--disable-timesyncd) TIMESYNCD=no;;
 	--enable-timesyncd) TIMESYNCD=yes; NTP=yes;;
 	--privsepuser) PRIVSEP_USER=$var;;
 	--prefix) PREFIX=$var;prefix=$var;; # prefix is set for autotools compat
@@ -1708,47 +1711,57 @@ fi
 HOOKS=
 if ! $HOOKSET; then
     if ! [ "$NTP" = "no" ]; then
-		printf "Checking for ntpd ... "
-		NTPD_PATH=$(_which ntpd)
-		if [ -n "$NTPD_PATH" ]; then
-			NTPD=yes
-			NTP=yes
-			echo "$NTPD_PATH (Selecting 50-ntp.conf)"
-		else
-			echo "not found"
-		fi
-		printf "Checking for chronyd ... "
-		CHRONYD_PATH=$(_which chronyd)
-		if [ -n "$CHRONYD_PATH" ]; then
-			NTPD=yes
-			NTP=yes
-			echo "$CHRONYD_PATH (Selecting 50-ntp.conf)"
-		else
-			echo "not found"
-		fi
-		
-		# Warn if both are detected
-		if [ -n "$NTPD_PATH" ] && [ -n "$CHRONYD_PATH" ]; then
-			echo "NTP will default to $NTPD_PATH"
+	    printf "Checking for ntpd ... "
+	    if [ -z "$NTPD" ]; then
+		    # if not explicitly set enable/disable, try to autodetect
+			
+			NTPD_PATH=$(_which ntpd)
+			if [ -n "$NTPD_PATH" ]; then
+				NTPD=yes
+				NTP=yes
+				echo "$NTPD_PATH (Selecting 50-ntp.conf)"
+			else
+				echo "not found"
+			fi
+			printf "Checking for chronyd ... "
+			CHRONYD_PATH=$(_which chronyd)
+			if [ -n "$CHRONYD_PATH" ]; then
+				NTPD=yes
+				NTP=yes
+				echo "$CHRONYD_PATH (Selecting 50-ntp.conf)"
+			else
+				echo "not found"
+			fi
+			
+			# Warn if both are detected
+			if [ -n "$NTPD_PATH" ] && [ -n "$CHRONYD_PATH" ]; then
+				echo "NTP will default to $NTPD_PATH"
+			fi
+		elif [ "$NTPD" = "no" ]; then
+			echo "skipped"
 		fi
 
 		printf "Checking for timesyncd ... "
-		TIMESYNCD_PATH=
-		for x in /usr/lib/systemd/systemd-timesyncd; do
-			if [ -x "$x" ]; then
-				TIMESYNCD=yes
-				TIMESYNCD_PATH=$x
-				NTP=yes
-				break
+		if [ -z "$TIMESYNCD" ]; then
+			TIMESYNCD_PATH=
+			for x in /usr/lib/systemd/systemd-timesyncd; do
+				if [ -x "$x" ]; then
+					TIMESYNCD=yes
+					TIMESYNCD_PATH=$x
+					NTP=yes
+					break
+				fi
+			done
+			if [ "$TIMESYNCD" = "yes" ]; then
+				echo "$TIMESYNCD_PATH (Selecting 50-timesyncd.conf)"
+			else
+				echo "not found"
 			fi
-		done
-		if [ "$TIMESYNCD" = "yes" ]; then
-			echo "$TIMESYNCD_PATH (Selecting 50-timesyncd.conf)"
-		else
-			echo "not found"
+		elif [ "$TIMESYNCD" = "no" ]; then
+			echo "skipped"
 		fi
 
-		 # Warn if both ntpd/chronyd and timesyncd are detected
+		# Warn if both ntpd/chronyd and timesyncd are detected
 		if [ "$NTPD" = "yes" ] && [ -n "$TIMESYNCD_PATH" ]; then
 			echo "Both ntpd/chronyd and timesyncd detected; NTP will default to ntpd"
 		fi

--- a/hooks/50-timesyncd.conf
+++ b/hooks/50-timesyncd.conf
@@ -1,7 +1,8 @@
 if [ ! -d /run/systemd/system ]; then
 	return
 fi
-if [ ! -x /lib/systemd/systemd-timesyncd ]; then
+if [ ! -x /lib/systemd/systemd-timesyncd ] && \
+	[ ! -x /usr/lib/systemd/systemd-timesyncd ]; then
 	return
 fi
 


### PR DESCRIPTION
If --enable-ntpd or --enable-timesyncd, assume --enable-ntp and
choose the appropriate hook file.

Will complain if --enable-ntpd or --enable-timesyncd are both set,
allows override of autodetect.

Autodetect will enable ntp functionality unless explicitly told not
to via --disable-ntp. If --disable-ntp is used, no time hooks
are installed.

Addresses #574
