### PR TITLE
dhcpcd 10.3 CVE-2026-56114 and 56116

### DIFF
--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -1093,7 +1093,7 @@ dhcp6_makemessage(struct interface *ifp)
 
 				/* RFC6603 Section 4.2 */
 				if (ap->prefix_exclude_len) {
-					uint8_t exb[16], *ep, u8;
+					uint8_t exb[17], *ep, u8;
 					const uint8_t *pp;
 
 					n = (size_t)((ap->prefix_exclude_len -

--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -1789,6 +1789,7 @@ ipv6nd_expirera(void *arg)
 				logwarnx("%s: expired route %s",
 				    rap->iface->name, rinfo->sprefix);
 				TAILQ_REMOVE(&rap->rinfos, rinfo, next);
+				free(rinfo);
 			}
 		}
 


### PR DESCRIPTION
DHCPv6: Prefix exclude option can be 17 octets (https://github.com/NetworkConfiguration/dhcpcd/pull/671)
https://www.cve.org/CVERecord?id=CVE-2026-56114

IPv6ND: Free routeinfo when it expires (https://github.com/NetworkConfiguration/dhcpcd/pull/670)
https://www.cve.org/CVERecord?id=CVE-2026-56116