### PR TITLE
ipv6nd: don't leave a carrier expiry timeout on a freed interface

### DIFF
--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -454,17 +454,31 @@ ipv6nd_expire(void *arg)
 	ipv6nd_expirera(ifp);
 }
 
+static void
+ipv6nd_cancelexpire(struct interface *ifp)
+{
+	eloop_q_timeout_delete(ifp->ctx->eloop, ELOOP_IPV6RA_EXPIRE,
+	    ipv6nd_expire, ifp);
+}
+
 void
 ipv6nd_startexpire(struct interface *ifp)
 {
 	struct ra *rap;
+	bool found = false;
 
 	if (ifp->ctx->ra_routers == NULL)
 		return;
 
 	TAILQ_FOREACH(rap, ifp->ctx->ra_routers, next) {
-		if (rap->iface == ifp)
+		if (rap->iface == ifp) {
 			rap->willexpire = true;
+			found = true;
+		}
+	}
+	if (!found) {
+		ipv6nd_cancelexpire(ifp);
+		return;
 	}
 	eloop_q_timeout_add_sec(ifp->ctx->eloop, ELOOP_IPV6RA_EXPIRE,
 	    RTR_CARRIER_EXPIRE, ipv6nd_expire, ifp);
@@ -681,8 +695,6 @@ ipv6nd_removefreedrop_ra(struct ra *rap, int remove_ra, int drop_ra)
 {
 	struct dhcpcd_ctx *ctx = rap->iface->ctx;
 
-	eloop_q_timeout_delete(ctx->eloop, ELOOP_IPV6RA_EXPIRE, NULL,
-	    rap->iface);
 	eloop_timeout_delete(ctx->eloop, NULL, rap->iface);
 	eloop_timeout_delete(ctx->eloop, NULL, rap);
 	if (remove_ra)
@@ -712,6 +724,7 @@ ipv6nd_free(struct interface *ifp)
 		return 0;
 
 	ctx = ifp->ctx;
+	ipv6nd_cancelexpire(ifp);
 #ifdef __sun
 	eloop_event_delete(ctx->eloop, state->nd_fd);
 	close(state->nd_fd);
@@ -1935,6 +1948,7 @@ ipv6nd_drop(struct interface *ifp)
 	struct ra *rap, *ran;
 	bool expired = false;
 
+	ipv6nd_cancelexpire(ifp);
 	if (ifp->ctx->ra_routers == NULL)
 		return;
 


### PR DESCRIPTION
An attempt at #614.

dhcpcd faults about 17 seconds after a veth gains carrier and is then
removed, but only when that interface never received an RA. On this
machine dhcpcd 10.3.2 hits it whenever a docker container starts, which
is the same version and trigger as #566.

Reproducer:

```sh
#!/bin/sh
# unshare -rn sh repro.sh /path/to/dhcpcd/src/dhcpcd
#
# build it with its own directories or it will fight the dhcpcd already
# running on the machine over the pidfile, control socket and duid:
#   d=$(mktemp -d)
#   CC=clang ./configure --sanitize --disable-privsep \
#       --rundir="$d/run" --dbdir="$d/db"

ip link set lo up
ip link add veth0 type veth peer name veth1	# left down on purpose

"$1" -d -B --script=/bin/true --nohook=all --noipv4 veth0 &
pid=$!
sleep 4

ip link set veth1 up
ip link set veth0 up		# carrier acquired, ipv6nd_startexpire()
sleep 3

ip link del veth0		# interface departed, if_free(ifp)
sleep 20			# RTR_CARRIER_EXPIRE is 17

kill $pid 2>/dev/null
wait $pid
```

The veth has to start down or dhcpcd never sees the carrier transition
and `dhcpcd_handlecarrier()` returns early on `was_link_up`.

On master (7c87dfdf), from a git checkout so `--sanitize` is not
silently dropped:

```
==11428==ERROR: AddressSanitizer: heap-use-after-free
READ of size 8
    #0 ipv6nd_expire src/ipv6nd.c:447
    #1 eloop_start src/eloop.c:1167

freed by thread T0 here:
    #1 dhcpcd_handleinterface src/dhcpcd.c:1096
    #4 if_handlelink src/if-linux.c:1196

previously allocated by thread T0 here:
    #1 if_discover src/if.c:570
```

That is `ifp->ctx->ra_routers` at the top of `ipv6nd_expire()`, same as
the backtrace in gentoo 966588 comment 30.

`ipv6nd_startexpire()` guards on `ra_routers == NULL`, but `ipv6_init()`
allocates that head as an empty TAILQ, so the guard passes even when the
interface has no routers and the timeout is added anyway. It then
outlives `if_free()`. `ipv6nd_free()` needs the cancel as well, since an
interface that is no longer active skips `stop_interface()` when it
departs (`dhcpcd.c:1091`).

The cancel 2a3fb4ef added to `ipv6nd_removefreedrop_ra()` is never
reached in that case, and taking out an interface wide timeout from a
per router path also stops the carrier expiry of the interface's other
routers, so I dropped it. ASan is clean either way when an RA is
accepted before the interface is deleted, so keep the line if you
prefer.

The reproducer is clean after the patch with and without an RA, and the
CI matrix builds and passes `make tests` locally.