### PR TITLE
ipv4: clear added state if we didn't delete the address

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -757,6 +757,8 @@ ipv4_applyaddr(void *arg)
 				/* Someone might have deleted our address */
 				if (state->addr != NULL)
 					ipv4_deladdr(state->addr, 0);
+				/* No address, ensure state is cleared  */
+				state->added = 0;
 				rt_build(ifp->ctx, AF_INET);
 			}
 			script_runreason(ifp, state->reason);


### PR DESCRIPTION
Thanks to MatthieuLgs for the diagnosis and fix.

Fixes #674 and #693.