### PR TITLE
compat: define __STDC_WANT_LIB_EXT1__ 1 before including config

### DIFF
--- a/compat/memset_explicit.c
+++ b/compat/memset_explicit.c
@@ -26,12 +26,10 @@
  * SUCH DAMAGE.
  */
 
-
 #define	__STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
 
 #include "config.h"
-
 
 void *
 memset_explicit(void *b, int c, size_t len)

--- a/compat/memset_explicit.c
+++ b/compat/memset_explicit.c
@@ -27,10 +27,11 @@
  */
 
 
-#include "config.h"
-
 #define	__STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
+
+#include "config.h"
+
 
 void *
 memset_explicit(void *b, int c, size_t len)


### PR DESCRIPTION
Fixes a compile warning on sunos