### PR TITLE
Filter route messages for tables dhcpcd ignores, so foreign-table churn can't overflow netlink

### DIFF
--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -546,7 +546,7 @@ if_opensockets_os(struct dhcpcd_ctx *ctx)
 	struct priv *priv;
 	struct sockaddr_nl snl;
 	socklen_t len;
-#ifdef NETLINK_BROADCAST_ERROR
+#if defined(NETLINK_BROADCAST_ERROR) || defined(NETLINK_GET_STRICT_CHK)
 	int on = 1;
 #endif
 
@@ -590,6 +590,26 @@ setup_priv:
 	priv->route_fd = if_linksocket(&snl, NETLINK_ROUTE, 0, false);
 	if (priv->route_fd == -1)
 		return -1;
+#ifdef NETLINK_GET_STRICT_CHK
+	/*
+	 * Ask the kernel to honour the filters we put in dump requests.
+	 * Without this it ignores them: if_initrt() asks for RT_TABLE_MAIN and
+	 * gets every table, and if_addrflags6() asks for one interface and gets
+	 * every address on the system.  Both then filter in userland, so the
+	 * result is unchanged -- but on a host whose routing daemon holds a
+	 * full BGP feed in its own kernel table, that is a quarter of a million
+	 * messages per dump to keep a handful, and rt_build() dumps on events
+	 * as frequent as a Router Advertisement.
+	 *
+	 * This must be done here rather than around each dump because the
+	 * privsep sandbox does not permit setsockopt(2) once it is in force.
+	 * Kernels without the option simply keep the old behaviour.
+	 */
+	if (setsockopt(priv->route_fd, SOL_NETLINK, NETLINK_GET_STRICT_CHK, &on,
+		sizeof(on)) == -1 &&
+	    errno != ENOPROTOOPT)
+		logerr("%s: NETLINK_GET_STRICT_CHK", __func__);
+#endif
 	len = sizeof(snl);
 	if (getsockname(priv->route_fd, (struct sockaddr *)&snl, &len) == -1)
 		return -1;

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -413,8 +413,67 @@ if_vlanid(const struct interface *ifp)
 	return (unsigned short)v.u.VID;
 }
 
+#ifdef SO_ATTACH_FILTER
+/*
+ * Reject route messages for tables we do not manage before the kernel queues
+ * them.  if_copyrt() already discards everything outside RT_TABLE_MAIN, but by
+ * then the message has been allocated, queued and charged against SO_RCVBUF.
+ * A routing daemon churning a large foreign table -- a full BGP feed in its own
+ * "kernel table N" -- can therefore overflow the socket in milliseconds and
+ * cost us the link and address messages we actually need.
+ *
+ * A broadcast rejected here is never queued and never charged, so no amount of
+ * foreign-table churn can overflow us.  The test mirrors if_copyrt() exactly,
+ * so nothing dhcpcd would have acted upon is affected.
+ *
+ * A table id wider than rtm_table's 8 bits is reported as RT_TABLE_COMPAT with
+ * the real id in RTA_TABLE, which cBPF cannot walk.  That needs no special
+ * case: accepting nothing but RT_TABLE_MAIN is the same test if_copyrt() makes,
+ * so the widest tables are kept out of the queue along with the rest.
+ */
+/*
+ * htons() is not a constant expression, so swap the comparands at compile
+ * time; BPF loads big endian while netlink is host endian.
+ */
+#if BYTE_ORDER == BIG_ENDIAN
+#define BPF_NLMSG_TYPE(t) (t)
+#else
+#define BPF_NLMSG_TYPE(t) ((((t) & 0xff) << 8) | (((t) >> 8) & 0xff))
+#endif
+
+static int
+if_linkfilter(int fd)
+{
+	/* A constant program; keep it out of the stack frame. */
+	static struct sock_filter filter[] = {
+		/* A = nlmsghdr.nlmsg_type. */
+		BPF_STMT(BPF_LD | BPF_H | BPF_ABS,
+		    offsetof(struct nlmsghdr, nlmsg_type)),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+		    BPF_NLMSG_TYPE(RTM_NEWROUTE), 1, 0),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+		    BPF_NLMSG_TYPE(RTM_DELROUTE), 0, 2), /* not a route */
+
+		/* A = rtmsg.rtm_table. */
+		BPF_STMT(BPF_LD | BPF_B | BPF_ABS,
+		    NLMSG_LENGTH(0) + offsetof(struct rtmsg, rtm_table)),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, RT_TABLE_MAIN, 0, 1),
+
+		BPF_STMT(BPF_RET | BPF_K, (uint32_t)-1), /* accept */
+		BPF_STMT(BPF_RET | BPF_K, 0),		 /* drop */
+	};
+	struct sock_fprog prog = {
+		.len = __arraycount(filter),
+		.filter = filter,
+	};
+
+	return setsockopt(fd, SOL_SOCKET, SO_ATTACH_FILTER, &prog,
+	    sizeof(prog));
+}
+#endif
+
 int
-if_linksocket(struct sockaddr_nl *nl, int protocol, int flags)
+if_linksocket(struct sockaddr_nl *nl, int protocol, int flags, bool filter)
 {
 	int fd;
 
@@ -422,6 +481,16 @@ if_linksocket(struct sockaddr_nl *nl, int protocol, int flags)
 	if (fd == -1)
 		return -1;
 	nl->nl_family = AF_NETLINK;
+#ifdef SO_ATTACH_FILTER
+	/*
+	 * Attach before bind(2) so that not even the leading messages of a
+	 * flood already in progress can be queued unfiltered.
+	 */
+	if (filter && if_linkfilter(fd) == -1)
+		logerr("%s: SO_ATTACH_FILTER", __func__);
+#else
+	UNUSED(filter);
+#endif
 	if (bind(fd, (struct sockaddr *)nl, sizeof(*nl)) == -1) {
 		close(fd);
 		return -1;
@@ -501,7 +570,7 @@ if_opensockets_os(struct dhcpcd_ctx *ctx)
 	snl.nl_groups |= RTMGRP_IPV6_ROUTE | RTMGRP_IPV6_IFADDR | RTMGRP_NEIGH;
 #endif
 
-	ctx->link_fd = if_linksocket(&snl, NETLINK_ROUTE, SOCK_NONBLOCK);
+	ctx->link_fd = if_linksocket(&snl, NETLINK_ROUTE, SOCK_NONBLOCK, true);
 	if (ctx->link_fd == -1)
 		return -1;
 #ifdef NETLINK_BROADCAST_ERROR
@@ -518,7 +587,7 @@ setup_priv:
 
 	ctx->priv = priv;
 	memset(&snl, 0, sizeof(snl));
-	priv->route_fd = if_linksocket(&snl, NETLINK_ROUTE, 0);
+	priv->route_fd = if_linksocket(&snl, NETLINK_ROUTE, 0, false);
 	if (priv->route_fd == -1)
 		return -1;
 	len = sizeof(snl);
@@ -527,7 +596,7 @@ setup_priv:
 	priv->route_pid = snl.nl_pid;
 
 	memset(&snl, 0, sizeof(snl));
-	priv->generic_fd = if_linksocket(&snl, NETLINK_GENERIC, 0);
+	priv->generic_fd = if_linksocket(&snl, NETLINK_GENERIC, 0, false);
 	if (priv->generic_fd == -1)
 		return -1;
 

--- a/src/if.h
+++ b/src/if.h
@@ -287,7 +287,7 @@ struct interface *if_findifpfromcmsg(struct dhcpcd_ctx *, struct msghdr *,
     int *);
 
 #ifdef __linux__
-int if_linksocket(struct sockaddr_nl *, int, int);
+int if_linksocket(struct sockaddr_nl *, int, int, bool);
 int if_getnetlink(struct dhcpcd_ctx *, struct iovec *, int, int,
     int (*)(struct dhcpcd_ctx *, void *, struct nlmsghdr *), void *);
 #endif


### PR DESCRIPTION
I have a full IPv6 table with ~250 000 routes in route table 100. Without these two patches dhcpcd takes 56-244 seconds until the IPv6 address is available. With these patches I'm down to 4 - 5 seconds.

2026-07-03  02:35:20 → 02:36:53     92.3s
2026-07-04  02:35:24 → 02:37:02     97.5s
2026-07-05  02:35:28 → 02:37:10    102.6s
2026-07-06  02:35:31 → 02:36:51     80.2s
2026-07-07  05:49:04 → 05:50:32     87.8s
2026-07-08  05:49:08 → 05:50:19     70.2s
2026-07-09  05:49:13 → 05:50:15     61.4s
2026-07-10  05:49:16 → 05:50:51     94.9s
2026-07-11  05:49:19 → 05:50:38     78.6s
2026-07-12  05:49:22 → 05:50:50     87.4s
2026-07-13  05:49:27 → 05:50:48     81.8s
2026-07-14  05:49:31 → 05:50:39     68.2s
2026-07-15  05:49:34 → 05:51:11     96.6s
2026-07-16  05:49:37 → 05:51:23    106.1s
2026-07-17  05:49:41 → 05:51:20     99.5s
2026-07-18  05:49:45 → 05:51:57    132.0s
2026-07-19  05:49:48 → 05:51:05     76.8s
2026-07-20  05:49:52 → 05:53:38    225.3s
2026-07-21  05:49:57 → 05:51:06     68.7s
2026-07-22  05:50:01 → 05:53:18    196.9s
2026-07-23  08:54:04 → 08:55:37     92.8s
2026-07-24  08:54:07 → 08:55:59    112.0s
2026-07-25  08:54:11 → 08:55:36     84.8s
2026-07-26  08:54:15 → 08:58:04    228.6s
2026-07-27  08:54:19 → 08:55:37     78.2s
2026-07-28  08:54:22 → 08:55:38     75.5s
2026-07-29  08:54:27 → 08:55:47     80.6s
2026-07-30  08:54:30 → 08:57:49    198.7s
2026-07-31  08:54:33 → 08:55:32     59.1s
2026-08-02  06:12:05 → 06:13:09     64.4s
2026-08-03  06:12:08 → 06:13:13     64.7s
2026-08-04  06:12:12 → 06:16:17    244.4s
2026-08-05  06:12:17 → 06:13:13     56.7s
2026-08-06  06:12:21 → 06:13:33     72.5s
2026-08-07  06:12:24 → 06:15:03    158.7s
2026-08-08  06:36:04 → 06:37:21     77.1s
2026-08-09  06:36:09 → 06:37:07     58.0s
2026-08-10  06:36:12 → 06:37:25     73.2s
2026-08-11  06:36:15 → 06:38:06    110.4s
2026-08-15  08:18:48 → 08:20:01     72.5s
2026-08-16  08:18:53 → 08:22:19    206.0s

n = 41;   min 56.7s    median 84.8s    mean 104.2s    max 244.4s
over 60s: 38/41        over 120s: 8/41