### PR TITLE
IPv6: Allocate the interface state before adding a static address

### DIFF
--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1748,11 +1748,13 @@ ipv6_startstatic(struct interface *ifp)
 	if (ia == NULL) {
 		struct ipv6_state *state;
 
+		state = ipv6_getstate(ifp);
+		if (state == NULL)
+			return -1;
 		ia = ipv6_newaddr(ifp, &ifp->options->req_addr6,
 		    ifp->options->req_prefix_len, 0);
 		if (ia == NULL)
 			return -1;
-		state = IPV6_STATE(ifp);
 		TAILQ_INSERT_TAIL(&state->addrs, ia, next);
 		run_script = 0;
 	} else


### PR DESCRIPTION
Fixes #595.

dhcpcd dies when it starts a point-to-point interface that has no IPv6
address of its own, if a `static ip6_address=` applies to it. A WireGuard
interface is both from creation, so the reporter's `interface wg0` block is
enough.

Reproducer:

```sh
#!/bin/sh
# unshare -rn sh repro-595.sh /path/to/dhcpcd/src/dhcpcd
#
# build it with its own directories or it will fight the dhcpcd already
# running on the machine over the pidfile, control socket and duid:
#	./configure --rundir="$PWD/run" --dbdir="$PWD/db"

d=$(mktemp -d) || exit 1	# --config must be absolute: dhcpcd chdir("/")s
				# before re-reading it per interface
printf 'noipv4\ninterface wg0\n\tstatic ip6_address=2001:db8:0:20::1/64\n' >"$d/cfg"

ip link set lo up
ip link add wg0 type wireguard
ip link set wg0 up
ip -o link show wg0		# POINTOPOINT, LOWER_UP, and no link-local

timeout -s KILL 6 "$1" -B -d --script=/bin/true --nohook=all --config="$d/cfg" wg0
echo "exit $?"			# 139 unpatched, 137 patched
```

On 10.5.1 (2bb381e9), 5 runs of 5, last log line `wg0: IAID 77:67:30:00` as
in the reporter's syslog:

```
==31519==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008
==31519==The signal is caused by a READ memory access.
    #0 ipv6_startstatic      src/ipv6.c:1756
    #1 dhcpcd_startinterface src/dhcpcd.c:973
    #2 eloop_start           src/eloop.c:1167
    #3 main                  src/dhcpcd.c:2842
```

`ipv6_startstatic()` takes the state with `IPV6_STATE()`, which does not
allocate. `ipv6_tryaddlinklocal()` returns early on `IFF_POINTOPOINT`, so
`ipv6_addlinklocal()` never reaches `ipv6_getstate()`. With no address on
the interface, `ipv6_handleifa()` has not run either. `TAILQ_INSERT_TAIL()`
then reads `head->tqh_last` at offset 8 through a NULL head, the `segfault
at 8` in the report.

Bringing a WireGuard link up sets its `addrgenmode` to `none`, so the kernel
adds no link-local. gre, sit and ipip are point-to-point but keep `eui`, and
do not crash until `addrgenmode none` is set on one.

`e354743c` made this same change to the other call site in
`ipv6_addaddr1()` and did not touch this one. I take the state before
`ipv6_newaddr()` so a failure there does not leak the address.

A static outside an `interface` block is a global default. A running daemon
then dies when a WireGuard interface appears later, without the config ever
naming it. The shipped `dhcpcd.conf` has no `static ip6_address=`.

The reporter wondered about #224. That one faults in
`ipv6_handleifa_addrs()` off `if_getnetlink()`, so I do not think this patch
closes it.
