### PR TITLE
Don't wait forever for a control command reply

### DIFF
--- a/src/dhcpcd.8.in
+++ b/src/dhcpcd.8.in
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd July 5, 2026
+.Dd September 7, 2026
 .Dt DHCPCD 8
 .Os
 .Sh NAME
@@ -818,6 +818,24 @@ sends to match.
 If using a DUID in place of the ClientID, edit
 .Pa @DBDIR@/duid
 accordingly.
+.Pp
+When sending a command such as
+.Fl k , Fl Fl release
+or
+.Fl n , Fl Fl rebind
+to the running manager,
+.Nm
+waits a short while for the manager to report the result.
+Managers older than dhcpcd-10.5 action the command but never report a
+result, so
+.Nm
+logs
+.Dq timed out waiting for a reply from dhcpcd
+and assumes the command was actioned.
+This is expected if the
+.Nm
+binaries have been upgraded without restarting the running manager;
+restarting the manager stops the message.
 .Sh FILES
 .Bl -ohang
 .It Pa @SYSCONFDIR@/dhcpcd.conf

--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -42,6 +42,7 @@ static const char dhcpcd_copyright[] = "Copyright (c) 2006-2025 Roy Marples";
 #include <getopt.h>
 #include <limits.h>
 #include <paths.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1891,15 +1892,40 @@ err:
 	eloop_exit(ctx->eloop, EXIT_FAILURE);
 }
 
+/* How long to wait for the manager to report the result of a command.
+ * dhcpcd-10.5 introduced this reply; older managers action the command
+ * but never send one, so we must not wait for it forever. */
+#define	READERROR_TIMEOUT_MS	5000
+
 static int
 dhcpcd_readerror(struct dhcpcd_ctx *ctx)
 {
 	int error = 0;
 	ssize_t len;
+	struct pollfd pfd = { .fd = ctx->control_fd, .events = POLLIN };
+	int n;
+
+	/* The socket is blocking, so poll for the reply rather than
+	 * risk blocking in read(3) forever. */
+	do {
+		n = poll(&pfd, 1, READERROR_TIMEOUT_MS);
+	} while (n == -1 && errno == EINTR);
+	if (n == -1)
+		return -1;
+	if (n == 0) {
+		logwarnx("timed out waiting for a reply from dhcpcd; "
+		    "assuming the command was actioned "
+		    "(is the running dhcpcd older than %s?)", VERSION);
+		return 0;
+	}
 
 	len = read(ctx->control_fd, &error, sizeof(error));
 	if (len == -1)
 		return -1;
+	if (len == 0) {
+		/* An older dhcpcd closed the socket without replying. */
+		return 0;
+	}
 	if (len != sizeof(error)) {
 		errno = EINVAL;
 		return -1;


### PR DESCRIPTION
Fixes #723.

## Problem

dhcpcd-10.5 made the manager reply to a control command with an `int` error, and `dhcpcd_readerror()` consumes it with a blocking `read(3)`:

```c
len = read(ctx->control_fd, &error, sizeof(error));
```

Managers older than 10.5 have no `dhcpcd_readerror()` and never send that reply — the 10.3.2 client simply sent its command and exited. So a 10.5 client talking to a pre-10.5 manager blocks in `read(3)` forever. The manager receives and fully actions the command; only the reply the newer client waits for is missing.

This happens whenever the dhcpcd binaries are upgraded while the manager keeps running, which is the normal case for distributions that run `dhcpcd -q -b` from a service unit and do not restart it on upgrade. Every control command then hangs until the manager is restarted or the machine reboots.

On Debian it surfaces through ifupdown: `networking.service`'s `ExecStop` runs `ifdown -a`, which runs `dhcpcd -k <iface>`, which never returns. That adds ~3 minutes to the first shutdown after the upgrade — and because the blocked `read(3)` is restarted after `SIGTERM`, systemd's 90 s stop timeout does not end it either; it takes the second 90 s timeout and a `SIGKILL`.

## Fix

Poll the control socket with a 5 second timeout before reading, which is what `dhcpcd_readdump()` immediately below already does for lease dumps. On timeout, warn and assume the command was actioned — that is exactly what an older manager did. `EOF` is likewise treated as success, for a manager that closes without replying.

When the manager does reply, behaviour is completely unchanged: `poll()` returns immediately and the existing `read()` path runs as before.

## Testing

Built and tested on Debian forky/sid, amd64, privsep enabled, interface managed by ifupdown (`iface enp1s0 inet dhcp`). The same 10.5.2 tree built twice, with and without this commit, run back to back against a live manager:

| manager | client | elapsed | exit | result |
|---|---|---|---|---|
| 10.3.2 | 10.5.2 **unpatched** | 20 s | 137 | hung; had to be `SIGKILL`ed |
| 10.3.2 | 10.5.2 **patched** | 5 s | 0 | warns, then proceeds |
| 10.5.2 | 10.5.2 **patched** | 8 ms | 0 | unchanged fast path, no warning |

Unpatched, against a 10.3.2 manager:

```
elapsed=20s exit=137
output: sending commands to dhcpcd process
```

(exit 137 = `SIGKILL`; `timeout -s TERM` was not enough to end it, matching the systemd behaviour described above.)

Patched, against the same 10.3.2 manager:

```
elapsed=5s exit=0
output: sending commands to dhcpcd process
        timed out waiting for a reply from dhcpcd; assuming the command
        was actioned (is the running dhcpcd older than 10.5.2?)
```

Patched, against a matching 10.5.2 manager:

```
elapsed=8ms exit=0
output: sending commands to dhcpcd process
```

Error reporting is unaffected — a command refused by the control socket still fails promptly (`main: control_open: Permission denied`, exit 1, 12 ms) rather than being swallowed.

## Note on the timeout semantics

I chose "warn and treat as actioned" on timeout because that matches what a pre-10.5 manager actually does — it carries out the command and never replies — so failing would make `ifdown` report a failure for work that was in fact done. If you would rather have a timeout be a hard error, or prefer a different duration than the 5 s borrowed from `dhcpcd_readdump()`, I am happy to change it.
