### PR TITLE
Options: Preserve v6 `vendclass` CLI optarg when parsing enterprise number 

### DIFF
--- a/src/if-options.c
+++ b/src/if-options.c
@@ -2193,9 +2193,22 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		return -1;
 #else
 		fp = strwhite(arg);
-		if (fp)
-			*fp++ = '\0';
-		u = (uint32_t)strtou(arg, NULL, 0, 0, UINT32_MAX, &e);
+		bp = NULL;
+		/* Command line options are parsed globally and then replayed
+		 * per-interface using the same argv, so do not split optarg
+		 * in-place. Later passes still need the data after the EN. */
+		if (fp) {
+			dl = (size_t)(fp - arg);
+			bp = malloc(dl + 1);
+			if (!bp) {
+				logerr(__func__);
+				return -1;
+			}
+			memcpy(bp, arg, dl);
+			bp[dl] = '\0';
+		}
+		u = (uint32_t)strtou(bp ? bp : arg, NULL, 0, 0, UINT32_MAX, &e);
+		free(bp);
 		if (e) {
 			logerrx("invalid code: %s", arg);
 			return -1;


### PR DESCRIPTION
## The issue
When passing `--vendclass '<EN> <DATA>'` via CLI arguments, the packet itself is sent with empty data (only with the EN).

The `vendclass` parser split the enterprise number from its class data by writing a `NUL` into `optarg`. 
The command-line options are applied more than once: first while processing global options, then again when configuring each interface.

That made the first pass succeed because it kept a local pointer to the bytes after the separator, but it permanently shortened the shared `argv` string to the EN for later passes.

### Example
Calling
```
$ dhcpcd -6 --vendclass "1234 Hello" ...
```
Transmitted on the wire (dissected using `tshark`):
```
    Vendor Class
        Option: Vendor Class (16)
        Length: 6
        Enterprise ID: Linkage Software Inc. (1234)
        vendor-class-data:
```

Live-debugging with GDB confirms:
```
Breakpoint 2, parse_option (ctx=ctx@entry=0x7fffffffd978, ifname=ifname@entry=0x0, ifo=ifo@entry=0x56c940, opt=147, arg=0x56a6a0 "1234", ldop=ldop@entry=0x0, edop=0x0) at if-options.c:2198
2198			u = (uint32_t)strtou(arg, NULL, 0, 0, UINT32_MAX, &e);


(gdb) x/10bc arg
0x56a6a0:	49 '1'	50 '2'	51 '3'	52 '4'	0 '\000'	72 'H'	101 'e'	108 'l'
0x56a6a8:	108 'l'	111 'o'

(gdb) p arg
$1 = 0x56a6a0 "1234"

(gdb) p fp
$2 = 0x56a6a5 "Hello"
```

## The proposed fix
Parse the enterprise number from a temporary NUL-terminated copy instead, leaving `argv` intact so the per-interface pass can still see and encode the vendor-class data.
`fp` still advances via `strskipwhite` into the vendor-class portion - behavior matches the old in-place split without mutating shared optarg.

With this fix, calling the same `dhcpcd` command as above now trasmits:
```
    Vendor Class
        Option: Vendor Class (16)
        Length: 11
        Enterprise ID: Linkage Software Inc. (1234)
        vendor-class-data: Hello
```

And GDB showing:
```
(gdb) x/10bc arg
0x5824e0:	49 '1'	50 '2'	51 '3'	52 '4'	32 ' '	72 'H'	101 'e'	108 'l'
0x5824e8:	108 'l'	111 'o'
# The 5th byte is kept as whitespace rather than changed to \0 as before

(gdb) p bp
$1 = 0x5977a0 "1234"
(gdb) p arg
$2 = 0x5824e0 "1234 Hello"
```